### PR TITLE
Added UTF-8 meta tag to plotly template page

### DIFF
--- a/src/XPlot.Plotly/Main.fs
+++ b/src/XPlot.Plotly/Main.fs
@@ -11,6 +11,7 @@ module Html =
         """<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8" />
         <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     </head>
     <body>


### PR DESCRIPTION
I was pasting some french text with accents it came out garbled. This sets the encoding meta tag to utf-8, which should fix this kind of problem in most cases.