### PR TITLE
Fixed multiple y-axes

### DIFF
--- a/src/XPlot.Plotly/Layout.fs
+++ b/src/XPlot.Plotly/Layout.fs
@@ -126,7 +126,7 @@ type Layout() =
 
     member __.yaxis2
         with get () = Option.get _yaxis2
-        and set value = _yaxis <- Some value
+        and set value = _yaxis2 <- Some value
 
     member __.scene
         with get () = Option.get _scene

--- a/src/XPlot.Plotly/Tests/Scatter.fsx
+++ b/src/XPlot.Plotly/Tests/Scatter.fsx
@@ -243,6 +243,26 @@ module Chart5 =
     |> Chart.Plot
     |> Chart.Show
 
+
+// Multiple y axes plot
+module Chart6 =
+
+    let trace1 = Scatter(x = [1; 2; 3; 4], y = [10; 15; 13; 17])
+
+    let trace2 = Scatter(x = [2; 3; 4; 5], y = [160; 52; 114; 92], yaxis = "y2")
+    
+    let layout = 
+      Layout (
+        yaxis = Yaxis(title="Axis 1"),
+        yaxis2 = Yaxis(title="Axis 2", overlaying="y", side="right")
+    )
+    
+    Chart.Plot ([trace1; trace2], layout)
+    |> Chart.Show
+
+
+
+
 // ====================
 // Pipeline stype tests
 // ====================


### PR DESCRIPTION
I fixed the assignment of a second y-axis in a Layout. Previously yaxis2 was overwriting Layout.yaxis instead of Layout.yaxis2. I also created a new example that uses two y axes.