### PR TITLE
Quickstart tutorial, incorrect link fix

### DIFF
--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -18,8 +18,8 @@
         google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-    <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />
-    <script type="text/javascript" src="/XPlot/content/tips.js"></script>
+    <link type="text/css" rel="stylesheet" href="./content/style.css" />
+    <script type="text/javascript" src="./content/tips.js"></script>
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -45,7 +45,7 @@
                     <a href="http://numerics.mathdotnet.com/"><img height="16" width="16" src="http://fslab.org/img/thumbs/mathnet.png" /> Math.NET</a>
                 </li>
             </ul>
-            <h3 class="muted"><a href="/XPlot/">XPlot</a></h3>
+            <h3 class="muted"><a href="./">XPlot</a></h3>
         </div>
         <hr />
         <div class="row">
@@ -70,68 +70,68 @@
 
             </div>
             <div class="span3">
-                <img src="/XPlot/img/logo.png" alt="F# Project" style="width:130px;margin:20px" />
+                <img src="./img/logo.png" alt="F# Project" style="width:130px;margin:20px" />
                 <ul class="nav nav-list" id="menu" style="margin-top: 20px;">
                     <li class="nav-header">XPlot</li>
-                    <li><a href="/XPlot/">Home page</a></li>
+                    <li><a href="./">Home page</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
                     <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
-                    <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
-                    <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
+                    <li><a href="./license.html">License (Apache 2.0)</a></li>
+                    <li><a href="./release-notes.html">Release Notes</a></li>
 
-                    <li class="nav-header"><a href="/XPlot/google-charts.html">Google Charts</a></li>
-                    <li><a href="/XPlot/chart/google-annotation-chart.html">Annotation</a></li>
-                    <li><a href="/XPlot/chart/google-area-chart.html">Area</a></li>
-                    <li><a href="/XPlot/chart/google-bar-chart.html">Bar</a></li>
-                    <li><a href="/XPlot/chart/google-bubble-chart.html">Bubble</a></li>
-                    <li><a href="/XPlot/chart/google-calendar-chart.html">Calendar</a></li>
-                    <li><a href="/XPlot/chart/google-candlestick-chart.html">Candlestick</a></li>
-                    <li><a href="/XPlot/chart/google-column-chart.html">Column</a></li>
-                    <li><a href="/XPlot/chart/google-combo-chart.html">Combo</a></li>
-                    <li><a href="/XPlot/chart/google-gauge-chart.html">Gauge</a></li>
-                    <li><a href="/XPlot/chart/google-geo-chart.html">Geo</a></li>
-                    <li><a href="/XPlot/chart/google-histogram-chart.html">Histogram</a></li>
-                    <li><a href="/XPlot/chart/google-line-chart.html">Line</a></li>
-                    <li><a href="/XPlot/chart/google-map-chart.html">Map</a></li>
-                    <li><a href="/XPlot/chart/google-pie-chart.html">Pie</a></li>
-                    <li><a href="/XPlot/chart/google-sankey-diagram.html">Sankey</a></li>
-                    <li><a href="/XPlot/chart/google-scatter-chart.html">Scatter</a></li>
-                    <li><a href="/XPlot/chart/google-stepped-area-chart.html">Stepped Area</a></li>
-                    <li><a href="/XPlot/chart/google-timeline-chart.html">Timeline</a></li>
-                    <li><a href="/XPlot/chart/google-table-chart.html">Table</a></li>
-                    <li><a href="/XPlot/chart/google-treemap-chart.html">Treemap</a></li>
+                    <li class="nav-header"><a href="./google-charts.html">Google Charts</a></li>
+                    <li><a href="./chart/google-annotation-chart.html">Annotation</a></li>
+                    <li><a href="./chart/google-area-chart.html">Area</a></li>
+                    <li><a href="./chart/google-bar-chart.html">Bar</a></li>
+                    <li><a href="./chart/google-bubble-chart.html">Bubble</a></li>
+                    <li><a href="./chart/google-calendar-chart.html">Calendar</a></li>
+                    <li><a href="./chart/google-candlestick-chart.html">Candlestick</a></li>
+                    <li><a href="./chart/google-column-chart.html">Column</a></li>
+                    <li><a href="./chart/google-combo-chart.html">Combo</a></li>
+                    <li><a href="./chart/google-gauge-chart.html">Gauge</a></li>
+                    <li><a href="./chart/google-geo-chart.html">Geo</a></li>
+                    <li><a href="./chart/google-histogram-chart.html">Histogram</a></li>
+                    <li><a href="./chart/google-line-chart.html">Line</a></li>
+                    <li><a href="./chart/google-map-chart.html">Map</a></li>
+                    <li><a href="./chart/google-pie-chart.html">Pie</a></li>
+                    <li><a href="./chart/google-sankey-diagram.html">Sankey</a></li>
+                    <li><a href="./chart/google-scatter-chart.html">Scatter</a></li>
+                    <li><a href="./chart/google-stepped-area-chart.html">Stepped Area</a></li>
+                    <li><a href="./chart/google-timeline-chart.html">Timeline</a></li>
+                    <li><a href="./chart/google-table-chart.html">Table</a></li>
+                    <li><a href="./chart/google-treemap-chart.html">Treemap</a></li>
 
-                    <li class="nav-header"><a href="/XPlot/plotly.html">Plotly</a></li>
-                    <li><a href="/XPlot/chart/plotly-bar-charts.html">Bar</a></li>
-                    <li><a href="/XPlot/chart/plotly-line-scatter-plots.html">Line and Scatter Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-box-plots.html">Box Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-bubble-charts.html">Bubble Charts</a></li>
-                    <li><a href="/XPlot/chart/plotly-contour-plots.html">Contour Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-area-plots.html">Area Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-heatmaps.html">Heatmaps</a></li>
-                    <li><a href="/XPlot/chart/plotly-histograms.html">Histograms</a></li>
-                    <li><a href="/XPlot/chart/plotly-2d-histograms.html">2D Histograms</a></li>
-                    <li><a href="/XPlot/chart/plotly-polar-charts.html">Polar Charts</a></li>
-                    <li><a href="/XPlot/chart/plotly-time-series.html">Time Series</a></li>
-                    <li><a href="/XPlot/chart/plotly-multiple-chart-types.html">Multiple Chart Types</a></li>
-                    <li><a href="/XPlot/chart/plotly-log-plots.html">Log Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-3d-scatter-plots.html">3D Scatter Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-3d-surface-plots.html">3D Surface Plots</a></li>
-                    <li><a href="/XPlot/chart/plotly-3d-line-plots.html">3D Line Plots</a></li>
+                    <li class="nav-header"><a href="./plotly.html">Plotly</a></li>
+                    <li><a href="./chart/plotly-bar-charts.html">Bar</a></li>
+                    <li><a href="./chart/plotly-line-scatter-plots.html">Line and Scatter Plots</a></li>
+                    <li><a href="./chart/plotly-box-plots.html">Box Plots</a></li>
+                    <li><a href="./chart/plotly-bubble-charts.html">Bubble Charts</a></li>
+                    <li><a href="./chart/plotly-contour-plots.html">Contour Plots</a></li>
+                    <li><a href="./chart/plotly-area-plots.html">Area Plots</a></li>
+                    <li><a href="./chart/plotly-heatmaps.html">Heatmaps</a></li>
+                    <li><a href="./chart/plotly-histograms.html">Histograms</a></li>
+                    <li><a href="./chart/plotly-2d-histograms.html">2D Histograms</a></li>
+                    <li><a href="./chart/plotly-polar-charts.html">Polar Charts</a></li>
+                    <li><a href="./chart/plotly-time-series.html">Time Series</a></li>
+                    <li><a href="./chart/plotly-multiple-chart-types.html">Multiple Chart Types</a></li>
+                    <li><a href="./chart/plotly-log-plots.html">Log Plots</a></li>
+                    <li><a href="./chart/plotly-3d-scatter-plots.html">3D Scatter Plots</a></li>
+                    <li><a href="./chart/plotly-3d-surface-plots.html">3D Surface Plots</a></li>
+                    <li><a href="./chart/plotly-3d-line-plots.html">3D Line Plots</a></li>
 
                     <li class="nav-header">Documentation</li>
-                    <li><a href="/XPlot/reference/index.html">API Reference</a></li>
+                    <li><a href="./reference/index.html">API Reference</a></li>
                     <li class="divider"></li>
 
-                    <li><a href="/XPlot/reference/xplot-googlecharts-chart.html">Google Chart type</a></li>
-                    <li><a href="/XPlot/reference/xplot-googlecharts-configuration-options.html">Google Option type</a></li>
-                    <li><a href="/XPlot/reference/xplot-googlecharts-configuration.html">Google configuration module</a></li>
+                    <li><a href="./reference/xplot-googlecharts-chart.html">Google Chart type</a></li>
+                    <li><a href="./reference/xplot-googlecharts-configuration-options.html">Google Option type</a></li>
+                    <li><a href="./reference/xplot-googlecharts-configuration.html">Google configuration module</a></li>
 
                     <li class="divider"></li>
 
-                    <li><a href="/XPlot/reference/xplot-plotly-graph.html">Plotly Graph module</a></li>
-                    <li><a href="/XPlot/reference/xplot-plotly-graph-layout.html">Plotly Layout type</a></li>
+                    <li><a href="./reference/xplot-plotly-graph.html">Plotly Graph module</a></li>
+                    <li><a href="./reference/xplot-plotly-graph-layout.html">Plotly Layout type</a></li>
                 </ul>
             </div>
         </div>

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -127,7 +127,7 @@ Documentation
 -------------
 
 The documentation for the library is automatically generated from F# script files that you can find
-[in the `docs/content` folder on GitHub](https://github.com/tpetricek/XPlot/tree/master/docs/content). 
+[in the `docsrc/content` folder on GitHub](https://github.com/fslaborg/XPlot/tree/master/docsrc/content). 
 The links in the right panel point to a number of tutorials that demonstrate some common scenarios.
 You can also copy the source code from GitHub.
 

--- a/docsrc/content/quickstart.fsx
+++ b/docsrc/content/quickstart.fsx
@@ -23,7 +23,7 @@ This will create a file called `paket.dependencies`
 Modify `paket.dependencies` so that it looks like this:
 
 ```
-framework:45
+framework:net45
 source https://www.nuget.org/api/v2
 nuget XPlot.GoogleCharts
 ```
@@ -64,6 +64,8 @@ open XPlot.GoogleCharts
 [ 1 .. 10 ] |> Chart.Line |> Chart.Show
 
 (**
+Select all of the code you pasted in and press `Alt`+`Enter` to execute it.
+
 That's it! You should see a chart popping up in your browser.
 
 Notes

--- a/docsrc/content/quickstart.fsx
+++ b/docsrc/content/quickstart.fsx
@@ -1,0 +1,75 @@
+(**
+Your First XPlot Chart
+======================
+
+In this tutorial we will walk through creating a chart in the browser, 
+from an F# script running in [Visual Studio Code](https://code.visualstudio.com/).
+
+We assume that:
+
+- VS Code is already installed,
+- F# is already installed ([see fsharp.org under "Use"](http://fsharp.org/)), and
+- VS Code extensions [Ionide FSharp](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp) 
+and [Ionide Paket](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-paket) are installed.
+
+## Step 1: Download the package XPlot.GoogleChart
+
+Choose a folder where you want to work, and open it in VS Code.
+
+Then use `Ctrl`+`Shift`+`P` to bring up the command palette and type the command `Paket: Init`.
+
+This will create a file called `paket.dependencies`
+
+Modify `paket.dependencies` so that it looks like this:
+
+```
+framework:45
+source https://www.nuget.org/api/v2
+nuget XPlot.GoogleCharts
+```
+
+Bring up the command palette again with `Ctrl`+`Shift`+`P` and type `Paket: Install`.
+This installs the package in your folder. You will see two things:
+
+- a paket.lock file, 
+- and a "packages" directory, with the following structure:
+
+```
+/packages/
+    / Google.DataTable.Net.Wrapper/
+        / lib
+            / Google.DataTable.Net.Wrapper.dll
+    / XPlot.GoogleCharts
+        / lib
+            /net45
+                / XPlot.GoogleCharts.dll
+```
+                
+Now you are ready to start creating a chart.
+
+## Step 2: Creating a chart from a script
+
+First, create a new F# script file: `Script.fsx`.
+
+Copy-paste the following code into the editor:
+
+*)
+
+#I "./packages"
+#r "Google.DataTable.Net.Wrapper/lib/Google.DataTable.Net.Wrapper.dll"
+#r "XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
+open XPlot.GoogleCharts
+
+[ 1 .. 10 ] |> Chart.Line |> Chart.Show
+
+(**
+That's it! You should see a chart popping up in your browser.
+
+Notes
+
+- in the path `#r "XPlot.GoogleCharts/lib/net45/`, make sure "net45" is right, 
+this is based on `paket.dependencies`, specifically the .NET 4.5 framework part (`framework:net45`).
+- you will need an internet connection for the chart to render, as the code relies on Google-hosted services.
+
+*)


### PR DESCRIPTION
1) added a QuickStart tutorial, walking through creating a simple chart from VSCode using Paket. The goal is to have a beginner friendly, fail-proof example with a chart created within a couple of minutes.
2) also fixed issue #63 - an incorrect link on the front page.
We haven't added the QuickStart to the links, would appreciate feedback first. We also assume, based on the repository, that the generated html docs should also be added to the repository.
As a next step, we'd like to take a stab at reorganizing the index page, and perhaps also adding a "contributing" guide.
(this is joint work with @thuris and @SergeyZa)