### PR TITLE
Partial fix for issue #67

### DIFF
--- a/src/XPlot.GoogleCharts/Configuration.fs
+++ b/src/XPlot.GoogleCharts/Configuration.fs
@@ -1592,8 +1592,9 @@ module Configuration =
 
         member __.title
             with get() = 
-                titleField 
-                |> Option.defaultValue String.Empty
+                match titleField with
+                | None -> String.Empty
+                | Some(title) -> title
             and set(value) = titleField <- Some value
 
         member __.titlePosition

--- a/src/XPlot.GoogleCharts/Configuration.fs
+++ b/src/XPlot.GoogleCharts/Configuration.fs
@@ -1591,7 +1591,9 @@ module Configuration =
             and set(value) = themeField <- Some value
 
         member __.title
-            with get() = titleField.Value
+            with get() = 
+                titleField 
+                |> Option.defaultValue String.Empty
             and set(value) = titleField <- Some value
 
         member __.titlePosition

--- a/src/XPlot.GoogleCharts/Main.fs
+++ b/src/XPlot.GoogleCharts/Main.fs
@@ -387,7 +387,15 @@ type GoogleChart() =
             with _ -> __.options.legend <- Legend(position = "right") 
                 
     /// Sets the chart's configuration options.
-    member __.WithOptions options = __.options <- options
+    member __.WithOptions (options:Options) =
+        // If the chart title has been set,
+        // do not overwrite it.
+        let currentTitle = __.options.title        
+        if not (String.IsNullOrEmpty currentTitle)
+        then
+            options.title <- currentTitle
+            
+        __.options <- options
 
     /// Sets the chart's width and height.
     member __.WithSize (width, height) = 


### PR DESCRIPTION
Prevent Chart.WithOptions to overwrite title if a title has been set already.