### PR TITLE
Updates for 1.5.0 version bump

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -71,7 +71,7 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
     </PropertyGroup>
@@ -96,7 +96,7 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      
+
       <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
       <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ NuGet
 
 * [Plotly](http://www.nuget.org/packages/XPlot.Plotly/)
 
+Building
+-------------
+
+    .\build
+
+Release
+-------------
+
+    .\build target NuGet
+    set APIKEY=...
+    ..\FsLab\.nuget\NuGet.exe push bin\*.nupkg  %APIKEY% -Source https://www.nuget.org
+
 Contact
 -------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 1.5.0 - August 6, 2018
+* Update to FSHarp.Core 4.5.0.0
+* Use proper google download links
+* Doc updates
+
 ### 1.4.5 - February 16, 2018
 * Fixing documentation template
 

--- a/docs/d3.html
+++ b/docs/d3.html
@@ -13,9 +13,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docs/google-charts.html
+++ b/docs/google-charts.html
@@ -13,9 +13,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docs/license.html
+++ b/docs/license.html
@@ -12,9 +12,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docs/plotly.html
+++ b/docs/plotly.html
@@ -13,9 +13,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -13,9 +13,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -5,7 +5,7 @@
     <title>Namespaces - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -67,49 +67,65 @@
           <td class="type-name">
             <a href="xplot-d3-chart.html">Chart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-chartgallery.html">ChartGallery</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-color.html">Color</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-edge.html">Edge</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-forcelayoutchart.html">ForceLayoutChart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-link.html">Link</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-node.html">Node</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-nodelabel.html">NodeLabel</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -122,13 +138,17 @@
           <td class="module-name">
             <a href="xplot-d3-configuration.html">Configuration</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="module-name">
             <a href="xplot-d3-htmlgeneration.html">HtmlGeneration</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -145,31 +165,41 @@
           <td class="type-name">
             <a href="xplot-googlecharts-chart.html">Chart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-chartgallery.html">ChartGallery</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-googlechart.html">GoogleChart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-key.html">key</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-value.html">value</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -180,27 +210,35 @@
     <tbody>
         <tr>
           <td class="module-name">
-            <a href="xplot-googlecharts-deedle.html">Deedle</a>
-          </td>
-          <td class="xmldoc"></td>
-        </tr>
-        <tr>
-          <td class="module-name">
             <a href="xplot-googlecharts-configuration.html">Configuration</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="module-name">
             <a href="xplot-googlecharts-data.html">Data</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="module-name">
             <a href="xplot-googlecharts-html.html">Html</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
+        </tr>
+        <tr>
+          <td class="module-name">
+            <a href="xplot-googlecharts-deedle.html">Deedle</a>
+          </td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -217,37 +255,53 @@
           <td class="type-name">
             <a href="xplot-plotly-chart.html">Chart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-options.html">Options</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-plotly.html">Plotly</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+              <div class="alert alert-warning">
+              <strong>WARNING: </strong> This API is obsolete
+              <p>Use the Chart type instead.</p>
+              </div> 
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-plotlychart.html">PlotlyChart</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-key.html">key</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-value.html">value</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -260,19 +314,25 @@
           <td class="module-name">
             <a href="xplot-plotly-graph.html">Graph</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="module-name">
             <a href="xplot-plotly-html.html">Html</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="module-name">
             <a href="xplot-plotly-layout.html">Layout</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -288,7 +348,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -351,6 +411,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-chart.html
+++ b/docs/reference/xplot-d3-chart.html
@@ -5,7 +5,7 @@
     <title>Chart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Chart</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Static members</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="79">
             <strong>Signature:</strong> (edges:seq&lt;string * string&gt;) -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L201-201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L201-201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="80">
             <strong>Signature:</strong> nodes:seq&lt;Node&gt; -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L198-198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L198-198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -111,10 +112,10 @@
           </code>
           <div class="tip" id="81">
             <strong>Signature:</strong> (edges:seq&lt;string * string&gt;) -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L235-235" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L235-235" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -129,10 +130,10 @@
           </code>
           <div class="tip" id="82">
             <strong>Signature:</strong> nodes:seq&lt;Node&gt; -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L232-232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L232-232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -147,10 +148,10 @@
           </code>
           <div class="tip" id="83">
             <strong>Signature:</strong> chart:ForceLayoutChart -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L229-229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L229-229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -167,10 +168,10 @@
           </code>
           <div class="tip" id="84">
             <strong>Signature:</strong> charge:float -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L224-224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L224-224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -185,10 +186,10 @@
           </code>
           <div class="tip" id="85">
             <strong>Signature:</strong> (edgeOptions:(Edge -&gt; EdgeOptions)) -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L208-208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L208-208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -203,10 +204,10 @@
           </code>
           <div class="tip" id="86">
             <strong>Signature:</strong> gravity:float -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -221,10 +222,10 @@
           </code>
           <div class="tip" id="87">
             <strong>Signature:</strong> height:int -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L216-216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L216-216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -239,10 +240,10 @@
           </code>
           <div class="tip" id="88">
             <strong>Signature:</strong> (nodeOptions:(Node -&gt; NodeOptions)) -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L204-204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L204-204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -257,10 +258,10 @@
           </code>
           <div class="tip" id="89">
             <strong>Signature:</strong> width:int -&gt; chart:ForceLayoutChart -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L212-212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-chartgallery.html
+++ b/docs/reference/xplot-d3-chartgallery.html
@@ -5,7 +5,7 @@
     <title>ChartGallery - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>ChartGallery</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Union Cases</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="90">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L40-40" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -97,7 +98,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -160,6 +161,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-color.html
+++ b/docs/reference/xplot-d3-color.html
@@ -5,7 +5,7 @@
     <title>Color - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Color</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="91">
             <strong>Signature:</strong> byte<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L16-16" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L16-16" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="92">
             <strong>Signature:</strong> byte<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L15-15" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L15-15" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -111,10 +112,10 @@
           </code>
           <div class="tip" id="93">
             <strong>Signature:</strong> byte<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L14-14" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L14-14" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -133,7 +134,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -196,6 +197,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration-edgeoptions.html
+++ b/docs/reference/xplot-d3-configuration-edgeoptions.html
@@ -5,7 +5,7 @@
     <title>EdgeOptions - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>EdgeOptions</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-  <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+        <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="58">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L56-56" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L56-56" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="59">
             <strong>Signature:</strong> Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="60">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L55-55" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L55-55" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -134,7 +135,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -197,6 +198,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration-edgestyle.html
+++ b/docs/reference/xplot-d3-configuration-edgestyle.html
@@ -5,7 +5,7 @@
     <title>EdgeStyle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>EdgeStyle</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-  <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+        <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="61">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L62-62" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L62-62" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="62">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L60-60" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L60-60" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="63">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L61-61" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L61-61" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -134,7 +135,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -197,6 +198,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration-nodeoptions.html
+++ b/docs/reference/xplot-d3-configuration-nodeoptions.html
@@ -5,7 +5,7 @@
     <title>NodeOptions - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>NodeOptions</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-  <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+        <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="64">
             <strong>Signature:</strong> Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L37-37" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L37-37" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="65">
             <strong>Signature:</strong> Option&lt;NodeLabel&gt;<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L41-41" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L41-41" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="66">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L40-40" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -130,10 +131,10 @@
           </code>
           <div class="tip" id="67">
             <strong>Signature:</strong> Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L38-38" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L38-38" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -148,10 +149,10 @@
           </code>
           <div class="tip" id="68">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L39-39" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L39-39" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -170,7 +171,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -233,6 +234,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration-nodestyle.html
+++ b/docs/reference/xplot-d3-configuration-nodestyle.html
@@ -5,7 +5,7 @@
     <title>NodeStyle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>NodeStyle</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-  <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+        <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="69">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L45-45" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L45-45" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="70">
             <strong>Signature:</strong> List&lt;string * string&gt;<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L50-50" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L50-50" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="71">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L49-49" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L49-49" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -130,10 +131,10 @@
           </code>
           <div class="tip" id="72">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L48-48" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L48-48" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -148,10 +149,10 @@
           </code>
           <div class="tip" id="73">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L46-46" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="74">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L47-47" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L47-47" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -188,7 +189,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -251,6 +252,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration-options.html
+++ b/docs/reference/xplot-d3-configuration-options.html
@@ -5,7 +5,7 @@
     <title>Options - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Options</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-  <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+        <span>Parent Module: <a href="xplot-d3-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="75">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L69-69" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L69-69" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="76">
             <strong>Signature:</strong> Edge -&gt; EdgeOptions<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L66-66" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L66-66" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="77">
             <strong>Signature:</strong> float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -130,10 +131,10 @@
           </code>
           <div class="tip" id="78">
             <strong>Signature:</strong> Node -&gt; NodeOptions<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L67-67" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L67-67" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -152,7 +153,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -215,6 +216,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-configuration.html
+++ b/docs/reference/xplot-d3-configuration.html
@@ -5,7 +5,7 @@
     <title>Configuration - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Configuration</h1>
 <p>
   <span>Namespace: XPlot.D3</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -74,31 +79,41 @@
           <td class="type-name">
             <a href="xplot-d3-configuration-edgeoptions.html">EdgeOptions</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-configuration-edgestyle.html">EdgeStyle</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-configuration-nodeoptions.html">NodeOptions</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-configuration-nodestyle.html">NodeStyle</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-d3-configuration-options.html">Options</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -119,10 +134,10 @@
           </code>
           <div class="tip" id="1">
             <strong>Signature:</strong> EdgeOptions<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L84-84" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L84-84" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -137,10 +152,10 @@
           </code>
           <div class="tip" id="2">
             <strong>Signature:</strong> NodeOptions<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L76-76" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L76-76" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -155,10 +170,10 @@
           </code>
           <div class="tip" id="3">
             <strong>Signature:</strong> Options<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L91-91" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L91-91" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,7 +192,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -240,6 +255,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-edge.html
+++ b/docs/reference/xplot-d3-edge.html
@@ -5,7 +5,7 @@
     <title>Edge - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Edge</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="94">
             <strong>Signature:</strong> Node<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L24-24" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L24-24" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="95">
             <strong>Signature:</strong> Node<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L25-25" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L25-25" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -115,7 +116,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -178,6 +179,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-forcelayoutchart.html
+++ b/docs/reference/xplot-d3-forcelayoutchart.html
@@ -5,7 +5,7 @@
     <title>ForceLayoutChart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>ForceLayoutChart</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,14 @@
           <div class="tip" id="96">
             <strong>Signature:</strong> seq&lt;Edge&gt;<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L50-50" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L50-50" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -95,10 +100,14 @@
           <div class="tip" id="97">
             <strong>Signature:</strong> seq&lt;Node&gt;<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L46-46" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,10 +123,14 @@
           <div class="tip" id="98">
             <strong>Signature:</strong> ChartGallery<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L55-55" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L55-55" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -140,10 +153,10 @@
           </code>
           <div class="tip" id="99">
             <strong>Signature:</strong> unit -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L43-43" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L43-43" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -167,10 +180,10 @@
           </code>
           <div class="tip" id="100">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L58-58" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L58-58" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -185,10 +198,10 @@
           </code>
           <div class="tip" id="101">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L79-79" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L79-79" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -203,10 +216,10 @@
           </code>
           <div class="tip" id="102">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L121-121" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L121-121" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -223,10 +236,10 @@
           </code>
           <div class="tip" id="103">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L142-142" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L142-142" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -242,10 +255,10 @@
           </code>
           <div class="tip" id="104">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L142-142" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L142-142" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -261,10 +274,10 @@
           </code>
           <div class="tip" id="105">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L157-157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L157-157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -282,10 +295,10 @@
           </code>
           <div class="tip" id="106">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L157-157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L157-157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -303,10 +316,10 @@
           </code>
           <div class="tip" id="107">
             <strong>Signature:</strong> unit -&gt; Options<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L57-57" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L57-57" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -322,10 +335,10 @@
           </code>
           <div class="tip" id="108">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L57-57" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L57-57" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -341,10 +354,10 @@
           </code>
           <div class="tip" id="109">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L71-71" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L71-71" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -361,10 +374,10 @@
           </code>
           <div class="tip" id="110">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L145-145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L145-145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -380,10 +393,10 @@
           </code>
           <div class="tip" id="111">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L145-145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L145-145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -399,10 +412,10 @@
           </code>
           <div class="tip" id="112">
             <strong>Signature:</strong> charge:float -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -417,10 +430,10 @@
           </code>
           <div class="tip" id="113">
             <strong>Signature:</strong> (edgeOptions:(Edge -&gt; EdgeOptions)) -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L168-168" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L168-168" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +448,10 @@
           </code>
           <div class="tip" id="114">
             <strong>Signature:</strong> gravity:float -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L162-162" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L162-162" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -453,10 +466,10 @@
           </code>
           <div class="tip" id="115">
             <strong>Signature:</strong> height:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L150-150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L150-150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +486,10 @@
           </code>
           <div class="tip" id="116">
             <strong>Signature:</strong> newId:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L154-154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L154-154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -493,10 +506,10 @@
           </code>
           <div class="tip" id="117">
             <strong>Signature:</strong> (nodeOptions:(Node -&gt; NodeOptions)) -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L171-171" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L171-171" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +524,10 @@
           </code>
           <div class="tip" id="118">
             <strong>Signature:</strong> width:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -537,10 +550,10 @@
           </code>
           <div class="tip" id="119">
             <strong>Signature:</strong> (edgeMappings:seq&lt;string * string&gt;) -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L180-180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L180-180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -555,10 +568,10 @@
           </code>
           <div class="tip" id="120">
             <strong>Signature:</strong> nodes:seq&lt;Node&gt; -&gt; ForceLayoutChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L174-174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L174-174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -577,7 +590,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -640,6 +653,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-htmlgeneration.html
+++ b/docs/reference/xplot-d3-htmlgeneration.html
@@ -5,7 +5,7 @@
     <title>HtmlGeneration - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,7 +58,7 @@
 <h1>HtmlGeneration</h1>
 <p>
   <span>Namespace: XPlot.D3</span><br />
-</p>
+  </p>
 <div class="xmldoc">
 </div>
 
@@ -78,10 +78,10 @@
           </code>
           <div class="tip" id="4">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L12-12" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L12-12" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -96,10 +96,10 @@
           </code>
           <div class="tip" id="5">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L11-11" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L11-11" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,10 +114,10 @@
           </code>
           <div class="tip" id="6">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L21-21" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Main.fs#L21-21" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -136,7 +136,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -199,6 +199,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-link.html
+++ b/docs/reference/xplot-d3-link.html
@@ -5,7 +5,7 @@
     <title>Link - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Link</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="121">
             <strong>Signature:</strong> int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L29-29" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L29-29" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="122">
             <strong>Signature:</strong> int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L30-30" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L30-30" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -115,7 +116,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -178,6 +179,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-node.html
+++ b/docs/reference/xplot-d3-node.html
@@ -5,7 +5,7 @@
     <title>Node - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Node</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="123">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L20-20" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L20-20" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -97,7 +98,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -160,6 +161,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-d3-nodelabel.html
+++ b/docs/reference/xplot-d3-nodelabel.html
@@ -5,7 +5,7 @@
     <title>NodeLabel - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>NodeLabel</h1>
 <p>
-  <span>Namespace: XPlot.D3</span><br />
-</p>
+
+    <span>Namespace: XPlot.D3</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="124">
             <strong>Signature:</strong> (string * string) list<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L10-10" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L10-10" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="125">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L9-9" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.D3/Configuration.fs#L9-9" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -115,7 +116,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -178,6 +179,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-chart.html
+++ b/docs/reference/xplot-googlecharts-chart.html
@@ -5,7 +5,7 @@
     <title>Chart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Chart</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Static members</h3>
@@ -74,11 +75,11 @@
             Annotation(data, Labels, Options)
           </code>
           <div class="tip" id="1190">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7751&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7751, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8116&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8116, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L525-525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L526-526" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,11 +95,11 @@
             Annotation(data, Labels, Options)
           </code>
           <div class="tip" id="1191">
-            <strong>Signature:</strong> (data:seq&lt;DateTime * &#39;?7749 * string * string&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7749          </div>
+            <strong>Signature:</strong> (data:seq&lt;DateTime * &#39;?8114 * string * string&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8114                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L518-518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L519-519" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,11 +115,11 @@
             Area(data, Labels, Options)
           </code>
           <div class="tip" id="1192">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7759&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7759, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8124&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8124, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L546-546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L547-547" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -134,11 +135,11 @@
             Area(data, Labels, Options)
           </code>
           <div class="tip" id="1193">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7756 * &#39;?7757&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7756, '?7757          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8121 * &#39;?8122&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8121, '?8122                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L539-539" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L540-540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -154,11 +155,11 @@
             Area(data, Labels, Options)
           </code>
           <div class="tip" id="1194">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7754&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7754          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8119&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8119                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L532-532" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L533-533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -174,11 +175,11 @@
             Bar(data, Labels, Options)
           </code>
           <div class="tip" id="1195">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7768&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7768, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8133&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8133, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L567-567" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L568-568" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -194,11 +195,11 @@
             Bar(data, Labels, Options)
           </code>
           <div class="tip" id="1196">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7765 * &#39;?7766&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7765, '?7766          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8130 * &#39;?8131&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8130, '?8131                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L560-560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L561-561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,11 +215,11 @@
             Bar(data, Labels, Options)
           </code>
           <div class="tip" id="1197">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7763&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7763          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8128&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8128                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L553-553" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L554-554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -234,11 +235,11 @@
             Bubble(data, Labels, Options)
           </code>
           <div class="tip" id="1198">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7779 * &#39;?7780 * &#39;?7781 * &#39;?7782&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7779, '?7780, '?7781, '?7782          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8144 * &#39;?8145 * &#39;?8146 * &#39;?8147&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8144, '?8145, '?8146, '?8147                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L588-588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L589-589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -254,11 +255,11 @@
             Bubble(data, Labels, Options)
           </code>
           <div class="tip" id="1199">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7775 * &#39;?7776 * &#39;?7777&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7775, '?7776, '?7777          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8140 * &#39;?8141 * &#39;?8142&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8140, '?8141, '?8142                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L581-581" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L582-582" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,11 +275,11 @@
             Bubble(data, Labels, Options)
           </code>
           <div class="tip" id="1200">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7772 * &#39;?7773&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7772, '?7773          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8137 * &#39;?8138&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8137, '?8138                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L574-574" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L575-575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -294,11 +295,11 @@
             Calendar(data, Labels, Options)
           </code>
           <div class="tip" id="1201">
-            <strong>Signature:</strong> (data:seq&lt;DateTime * &#39;?7784&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7784          </div>
+            <strong>Signature:</strong> (data:seq&lt;DateTime * &#39;?8149&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8149                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L595-595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L596-596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -314,11 +315,11 @@
             Candlestick(data, Labels, Options)
           </code>
           <div class="tip" id="1202">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7792&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7792, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8157&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8157, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L609-609" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L610-610" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,11 +335,11 @@
             Candlestick(data, Labels, Options)
           </code>
           <div class="tip" id="1203">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7786 * &#39;?7787 * &#39;?7788 * &#39;?7789 * &#39;?7790&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7786, '?7787, '?7788, '?7789, '?7790          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8151 * &#39;?8152 * &#39;?8153 * &#39;?8154 * &#39;?8155&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8151, '?8152, '?8153, '?8154, '?8155                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L602-602" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L603-603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -354,11 +355,11 @@
             Column(data, Labels, Options)
           </code>
           <div class="tip" id="1204">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7801&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7801, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8166&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8166, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L630-630" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L631-631" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -374,11 +375,11 @@
             Column(data, Labels, Options)
           </code>
           <div class="tip" id="1205">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7798 * &#39;?7799&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7798, '?7799          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8163 * &#39;?8164&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8163, '?8164                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L623-623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L624-624" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -394,11 +395,11 @@
             Column(data, Labels, Options)
           </code>
           <div class="tip" id="1206">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7796&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7796          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8161&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8161                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L616-616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L617-617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,11 +415,11 @@
             Combo(data, Labels, Options)
           </code>
           <div class="tip" id="1207">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7805&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7805, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8170&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8170, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L637-637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L638-638" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -434,11 +435,11 @@
             Gauge(data, Labels, Options)
           </code>
           <div class="tip" id="1208">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7809&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7809          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8174&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8174                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L644-644" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L645-645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -454,11 +455,11 @@
             Geo(data, Labels, Options)
           </code>
           <div class="tip" id="1209">
-            <strong>Signature:</strong> (data:seq&lt;float * float * &#39;?7819 * &#39;?7820&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7819, '?7820          </div>
+            <strong>Signature:</strong> (data:seq&lt;float * float * &#39;?8184 * &#39;?8185&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8184, '?8185                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L679-679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L680-680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -474,11 +475,11 @@
             Geo(data, Labels, Options)
           </code>
           <div class="tip" id="1210">
-            <strong>Signature:</strong> (data:seq&lt;float * float * &#39;?7817&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7817          </div>
+            <strong>Signature:</strong> (data:seq&lt;float * float * &#39;?8182&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8182                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L672-672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L673-673" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -495,10 +496,10 @@
           </code>
           <div class="tip" id="1211">
             <strong>Signature:</strong> (data:seq&lt;float * float&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L665-665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L666-666" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -514,11 +515,11 @@
             Geo(data, Labels, Options)
           </code>
           <div class="tip" id="1212">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7813 * &#39;?7814&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7813, '?7814          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8178 * &#39;?8179&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8178, '?8179                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L658-658" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L659-659" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -534,11 +535,11 @@
             Geo(data, Labels, Options)
           </code>
           <div class="tip" id="1213">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7811&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7811          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8176&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8176                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L651-651" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L652-652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -554,11 +555,11 @@
             Histogram(data, Labels, Options)
           </code>
           <div class="tip" id="1214">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7822&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7822          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8187&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8187                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L686-686" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L687-687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -574,11 +575,11 @@
             Line(data, Labels, Options)
           </code>
           <div class="tip" id="1215">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7829&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7829, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8194&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8194, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L707-707" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L708-708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -594,11 +595,11 @@
             Line(data, Labels, Options)
           </code>
           <div class="tip" id="1216">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7826 * &#39;?7827&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7826, '?7827          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8191 * &#39;?8192&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8191, '?8192                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L700-700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L701-701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -614,11 +615,11 @@
             Line(data, Labels, Options)
           </code>
           <div class="tip" id="1217">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7824&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7824          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8189&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8189                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L693-693" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L694-694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -635,10 +636,10 @@
           </code>
           <div class="tip" id="1218">
             <strong>Signature:</strong> (data:seq&lt;float * float * string&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L721-721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L722-722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -655,10 +656,10 @@
           </code>
           <div class="tip" id="1219">
             <strong>Signature:</strong> (data:seq&lt;string * string&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L714-714" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L715-715" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -674,11 +675,11 @@
             Pie(data, Labels, Options)
           </code>
           <div class="tip" id="1220">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7835&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7835          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8200&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8200                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L728-728" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L729-729" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -694,11 +695,11 @@
             Sankey(data, Labels, Options)
           </code>
           <div class="tip" id="1221">
-            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?7837&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7837          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?8202&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8202                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L735-735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L736-736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -714,11 +715,11 @@
             Scatter(data, Labels, Options)
           </code>
           <div class="tip" id="1222">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7844&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7844, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8209&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8209, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L756-756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L757-757" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -734,11 +735,11 @@
             Scatter(data, Labels, Options)
           </code>
           <div class="tip" id="1223">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7841 * &#39;?7842&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7841, '?7842          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8206 * &#39;?8207&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8206, '?8207                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L749-749" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L750-750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -754,11 +755,11 @@
             Scatter(data, Labels, Options)
           </code>
           <div class="tip" id="1224">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7839&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7839          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8204&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8204                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L742-742" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L743-743" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -775,10 +776,10 @@
           </code>
           <div class="tip" id="1225">
             <strong>Signature:</strong> chart:GoogleChart -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L429-429" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L430-430" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -794,11 +795,11 @@
             SteppedArea(data, Labels, Options)
           </code>
           <div class="tip" id="1226">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7851&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7851, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8216&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8216, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L770-770" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L771-771" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -814,11 +815,11 @@
             SteppedArea(data, Labels, Options)
           </code>
           <div class="tip" id="1227">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7848 * &#39;?7849&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7848, '?7849          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8213 * &#39;?8214&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8213, '?8214                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L763-763" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L764-764" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -834,11 +835,11 @@
             Table(data, Labels, Options)
           </code>
           <div class="tip" id="1228">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7858&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7858, 'K, 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8223&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8223, 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L784-784" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L785-785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -854,11 +855,11 @@
             Table(data, Labels, Options)
           </code>
           <div class="tip" id="1229">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7855 * &#39;?7856&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7855, '?7856          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8220 * &#39;?8221&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8220, '?8221                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L777-777" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L778-778" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -874,11 +875,11 @@
             Timeline(data, Labels, Options)
           </code>
           <div class="tip" id="1230">
-            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?7865 * &#39;?7866&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7865, '?7866          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?8230 * &#39;?8231&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8230, '?8231                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L798-798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L799-799" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -894,11 +895,11 @@
             Timeline(data, Labels, Options)
           </code>
           <div class="tip" id="1231">
-            <strong>Signature:</strong> (data:seq&lt;string * &#39;?7862 * &#39;?7863&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7862, '?7863          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * &#39;?8227 * &#39;?8228&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8227, '?8228                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L791-791" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L792-792" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -914,11 +915,11 @@
             Treemap(data, Labels, Options)
           </code>
           <div class="tip" id="1232">
-            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?7870 * &#39;?7871&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7870, '?7871          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?8235 * &#39;?8236&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8235, '?8236                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L812-812" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L813-813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -934,11 +935,11 @@
             Treemap(data, Labels, Options)
           </code>
           <div class="tip" id="1233">
-            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?7868&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7868          </div>
+            <strong>Signature:</strong> (data:seq&lt;string * string * &#39;?8233&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?8233                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L805-805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L806-806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -955,10 +956,10 @@
           </code>
           <div class="tip" id="1234">
             <strong>Signature:</strong> apiKey:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L442-442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L443-443" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -975,10 +976,10 @@
           </code>
           <div class="tip" id="1235">
             <strong>Signature:</strong> height:int -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L432-432" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L433-433" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -995,10 +996,10 @@
           </code>
           <div class="tip" id="1236">
             <strong>Signature:</strong> id:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L437-437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L438-438" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1015,10 +1016,10 @@
           </code>
           <div class="tip" id="1237">
             <strong>Signature:</strong> label:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L448-448" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L449-449" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1036,10 +1037,10 @@ chart's data is a single series.</p>
           </code>
           <div class="tip" id="1238">
             <strong>Signature:</strong> labels:seq&lt;string&gt; -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L454-454" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L455-455" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1057,10 +1058,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1239">
             <strong>Signature:</strong> enabled:bool -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L459-459" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L460-460" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1077,10 +1078,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1240">
             <strong>Signature:</strong> options:Options -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L464-464" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L465-465" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1097,10 +1098,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1241">
             <strong>Signature:</strong> (size:(int * int)) -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L469-469" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L470-470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1117,10 +1118,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1242">
             <strong>Signature:</strong> title:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L474-474" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L475-475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1137,10 +1138,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1243">
             <strong>Signature:</strong> width:int -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L479-479" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L480-480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1157,10 +1158,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1244">
             <strong>Signature:</strong> xTitle:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L484-484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L485-485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1177,10 +1178,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1245">
             <strong>Signature:</strong> yTitle:string -&gt; chart:GoogleChart -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L489-489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L490-490" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1201,7 +1202,7 @@ chart's data is a series collection.</p>
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1264,6 +1265,6 @@ chart's data is a series collection.</p>
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-chartgallery.html
+++ b/docs/reference/xplot-googlecharts-chartgallery.html
@@ -5,7 +5,7 @@
     <title>ChartGallery - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>ChartGallery</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Union Cases</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="1246">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L211-211" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -93,10 +94,10 @@
           </code>
           <div class="tip" id="1247">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L212-212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L213-213" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -111,10 +112,10 @@
           </code>
           <div class="tip" id="1248">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L213-213" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L214-214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -129,10 +130,10 @@
           </code>
           <div class="tip" id="1249">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L214-214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L215-215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -147,10 +148,10 @@
           </code>
           <div class="tip" id="1250">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L215-215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L216-216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -165,10 +166,10 @@
           </code>
           <div class="tip" id="1251">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L216-216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L217-217" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="1252">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L217-217" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L218-218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="1253">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L218-218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L219-219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="1254">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L219-219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="1255">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L221-221" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1256">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L221-221" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L222-222" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="1257">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L222-222" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L223-223" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="1258">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L223-223" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L224-224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="1259">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L224-224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L225-225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="1260">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L225-225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L226-226" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="1261">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L226-226" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L227-227" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -363,10 +364,10 @@
           </code>
           <div class="tip" id="1262">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L227-227" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L228-228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -381,10 +382,10 @@
           </code>
           <div class="tip" id="1263">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L228-228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L229-229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -399,10 +400,10 @@
           </code>
           <div class="tip" id="1264">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L229-229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L230-230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -417,10 +418,10 @@
           </code>
           <div class="tip" id="1265">
             <strong>Signature:</strong> <br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L230-230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L231-231" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,7 +440,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -502,6 +503,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-animation.html
+++ b/docs/reference/xplot-googlecharts-configuration-animation.html
@@ -5,7 +5,7 @@
     <title>Animation - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Animation</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="126">
             <strong>Signature:</strong> unit -&gt; Animation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L8-8" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L8-8" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="127">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L13-13" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L13-13" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="128">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L13-13" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L13-13" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="129">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L17-17" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L17-17" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="130">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L17-17" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L17-17" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="131">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L21-21" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L21-21" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="132">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L22-22" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L22-22" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-annotations.html
+++ b/docs/reference/xplot-googlecharts-configuration-annotations.html
@@ -5,7 +5,7 @@
     <title>Annotations - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Annotations</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="133">
             <strong>Signature:</strong> unit -&gt; Annotations<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L150-150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L150-150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="134">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L157-157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L157-157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="135">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L157-157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L157-157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="136">
             <strong>Signature:</strong> unit -&gt; BoxStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L161-161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L161-161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="137">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L161-161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L161-161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="138">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="139">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="140">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L173-173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L173-173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="141">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L174-174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L174-174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="142">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L175-175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L175-175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="143">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L176-176" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L176-176" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="144">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L169-169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -308,10 +309,10 @@
           </code>
           <div class="tip" id="145">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L169-169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,7 +332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -394,6 +395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-axis.html
+++ b/docs/reference/xplot-googlecharts-configuration-axis.html
@@ -5,7 +5,7 @@
     <title>Axis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Axis</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="146">
             <strong>Signature:</strong> unit -&gt; Axis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L364-364" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L364-364" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="147">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L438-438" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L438-438" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="148">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L438-438" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L438-438" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="149">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L390-390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L390-390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="150">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L390-390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L390-390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="151">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L394-394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L394-394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="152">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L394-394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L394-394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="153">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L398-398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L398-398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="154">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L398-398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L398-398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="155">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L402-402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L402-402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="156">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L402-402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L402-402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="157">
             <strong>Signature:</strong> unit -&gt; Gridlines<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L406-406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L406-406" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="158">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L406-406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L406-406" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="159">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L414-414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L414-414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -350,10 +351,10 @@
           </code>
           <div class="tip" id="160">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L414-414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L414-414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="161">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L450-450" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L450-450" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -388,10 +389,10 @@
           </code>
           <div class="tip" id="162">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L450-450" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L450-450" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="163">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L454-454" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L454-454" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -426,10 +427,10 @@
           </code>
           <div class="tip" id="164">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L454-454" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L454-454" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -445,10 +446,10 @@
           </code>
           <div class="tip" id="165">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L466-466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L466-466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -464,10 +465,10 @@
           </code>
           <div class="tip" id="166">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L466-466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L466-466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -483,10 +484,10 @@
           </code>
           <div class="tip" id="167">
             <strong>Signature:</strong> unit -&gt; Gridlines<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L410-410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L410-410" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="168">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L410-410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L410-410" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -521,10 +522,10 @@
           </code>
           <div class="tip" id="169">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L458-458" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L458-458" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -540,10 +541,10 @@
           </code>
           <div class="tip" id="170">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L458-458" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L458-458" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -559,10 +560,10 @@
           </code>
           <div class="tip" id="171">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L470-470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L470-470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="172">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L470-470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L470-470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -597,10 +598,10 @@
           </code>
           <div class="tip" id="173">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L494-494" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L494-494" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -615,10 +616,10 @@
           </code>
           <div class="tip" id="174">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L482-482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L482-482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="175">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L483-483" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L483-483" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -651,10 +652,10 @@
           </code>
           <div class="tip" id="176">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L484-484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L484-484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -669,10 +670,10 @@
           </code>
           <div class="tip" id="177">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L485-485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L485-485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -687,10 +688,10 @@
           </code>
           <div class="tip" id="178">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L486-486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L486-486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -705,10 +706,10 @@
           </code>
           <div class="tip" id="179">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L488-488" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L488-488" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -723,10 +724,10 @@
           </code>
           <div class="tip" id="180">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L497-497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L497-497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -741,10 +742,10 @@
           </code>
           <div class="tip" id="181">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L498-498" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L498-498" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -759,10 +760,10 @@
           </code>
           <div class="tip" id="182">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L501-501" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L501-501" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -777,10 +778,10 @@
           </code>
           <div class="tip" id="183">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L487-487" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L487-487" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -795,10 +796,10 @@
           </code>
           <div class="tip" id="184">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L499-499" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L499-499" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -813,10 +814,10 @@
           </code>
           <div class="tip" id="185">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L502-502" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L502-502" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -831,10 +832,10 @@
           </code>
           <div class="tip" id="186">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L500-500" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L500-500" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -849,10 +850,10 @@
           </code>
           <div class="tip" id="187">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L495-495" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L495-495" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -867,10 +868,10 @@
           </code>
           <div class="tip" id="188">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L496-496" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L496-496" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -885,10 +886,10 @@
           </code>
           <div class="tip" id="189">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L489-489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L489-489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -903,10 +904,10 @@
           </code>
           <div class="tip" id="190">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L490-490" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L490-490" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -921,10 +922,10 @@
           </code>
           <div class="tip" id="191">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L491-491" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L491-491" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -939,10 +940,10 @@
           </code>
           <div class="tip" id="192">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L492-492" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L492-492" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -957,10 +958,10 @@
           </code>
           <div class="tip" id="193">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L493-493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L493-493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -975,10 +976,10 @@
           </code>
           <div class="tip" id="194">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L504-504" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L504-504" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -993,10 +994,10 @@
           </code>
           <div class="tip" id="195">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L503-503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L503-503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1011,10 +1012,10 @@
           </code>
           <div class="tip" id="196">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L462-462" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L462-462" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1030,10 +1031,10 @@
           </code>
           <div class="tip" id="197">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L462-462" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L462-462" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1049,10 +1050,10 @@
           </code>
           <div class="tip" id="198">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L442-442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L442-442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1068,10 +1069,10 @@
           </code>
           <div class="tip" id="199">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L442-442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L442-442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1087,10 +1088,10 @@
           </code>
           <div class="tip" id="200">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L446-446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L446-446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1106,10 +1107,10 @@
           </code>
           <div class="tip" id="201">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L446-446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L446-446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="202">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L418-418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L418-418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1144,10 +1145,10 @@
           </code>
           <div class="tip" id="203">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L418-418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L418-418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1163,10 +1164,10 @@
           </code>
           <div class="tip" id="204">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L422-422" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L422-422" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1182,10 +1183,10 @@
           </code>
           <div class="tip" id="205">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L422-422" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L422-422" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1201,10 +1202,10 @@
           </code>
           <div class="tip" id="206">
             <strong>Signature:</strong> unit -&gt; obj []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L426-426" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L426-426" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1220,10 +1221,10 @@
           </code>
           <div class="tip" id="207">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L426-426" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L426-426" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1239,10 +1240,10 @@
           </code>
           <div class="tip" id="208">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L430-430" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L430-430" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1258,10 +1259,10 @@
           </code>
           <div class="tip" id="209">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L430-430" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L430-430" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1277,10 +1278,10 @@
           </code>
           <div class="tip" id="210">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L434-434" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L434-434" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1296,10 +1297,10 @@
           </code>
           <div class="tip" id="211">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L434-434" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L434-434" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1315,10 +1316,10 @@
           </code>
           <div class="tip" id="212">
             <strong>Signature:</strong> unit -&gt; ViewWindow<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L478-478" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L478-478" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1334,10 +1335,10 @@
           </code>
           <div class="tip" id="213">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L478-478" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L478-478" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1353,10 +1354,10 @@
           </code>
           <div class="tip" id="214">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L474-474" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L474-474" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1372,10 +1373,10 @@
           </code>
           <div class="tip" id="215">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L474-474" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L474-474" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1395,7 +1396,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1458,6 +1459,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-backgroundcolor.html
+++ b/docs/reference/xplot-googlecharts-configuration-backgroundcolor.html
@@ -5,7 +5,7 @@
     <title>BackgroundColor - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>BackgroundColor</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="216">
             <strong>Signature:</strong> unit -&gt; BackgroundColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L178-178" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L178-178" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="217">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L192-192" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L192-192" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="218">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L192-192" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L192-192" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="219">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L198-198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L198-198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -159,10 +160,10 @@
           </code>
           <div class="tip" id="220">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L196-196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L196-196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,10 +178,10 @@
           </code>
           <div class="tip" id="221">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L197-197" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L197-197" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="222">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L184-184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L184-184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="223">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L184-184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L184-184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="224">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L188-188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L188-188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="225">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L188-188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L188-188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-bar.html
+++ b/docs/reference/xplot-googlecharts-configuration-bar.html
@@ -5,7 +5,7 @@
     <title>Bar - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Bar</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="226">
             <strong>Signature:</strong> unit -&gt; Bar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L668-668" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L668-668" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="227">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L672-672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L672-672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="228">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L672-672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L672-672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="229">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L676-676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L676-676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,7 +164,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -226,6 +227,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-boxstyle.html
+++ b/docs/reference/xplot-googlecharts-configuration-boxstyle.html
@@ -5,7 +5,7 @@
     <title>BoxStyle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>BoxStyle</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="230">
             <strong>Signature:</strong> unit -&gt; BoxStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L70-70" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L70-70" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="231">
             <strong>Signature:</strong> unit -&gt; Gradient<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L94-94" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L94-94" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="232">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L94-94" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L94-94" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="233">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L86-86" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L86-86" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="234">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L86-86" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L86-86" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="235">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L90-90" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L90-90" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="236">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L90-90" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L90-90" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="237">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L102-102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L102-102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="238">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L100-100" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L100-100" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="239">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L101-101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L101-101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="240">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L98-98" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L98-98" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="241">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L99-99" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L99-99" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -307,10 +308,10 @@
           </code>
           <div class="tip" id="242">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L78-78" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L78-78" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="243">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L78-78" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L78-78" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="244">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L82-82" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L82-82" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="245">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L82-82" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L82-82" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-bubble.html
+++ b/docs/reference/xplot-googlecharts-configuration-bubble.html
@@ -5,7 +5,7 @@
     <title>Bubble - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Bubble</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="246">
             <strong>Signature:</strong> unit -&gt; Bubble<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L678-678" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L678-678" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="247">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L684-684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L684-684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="248">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L684-684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L684-684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="249">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L696-696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L696-696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -159,10 +160,10 @@
           </code>
           <div class="tip" id="250">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L697-697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L697-697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,10 +178,10 @@
           </code>
           <div class="tip" id="251">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L698-698" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L698-698" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="252">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L688-688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L688-688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="253">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L688-688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L688-688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="254">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L692-692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L692-692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="255">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L692-692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L692-692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-calendar.html
+++ b/docs/reference/xplot-googlecharts-configuration-calendar.html
@@ -5,7 +5,7 @@
     <title>Calendar - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Calendar</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="256">
             <strong>Signature:</strong> unit -&gt; Calendar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L756-756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L756-756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="257">
             <strong>Signature:</strong> unit -&gt; CellColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L770-770" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L770-770" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="258">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L770-770" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L770-770" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="259">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L774-774" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L774-774" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="260">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L774-774" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L774-774" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="261">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L778-778" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L778-778" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="262">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L778-778" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L778-778" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="263">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L782-782" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L782-782" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="264">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L782-782" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L782-782" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="265">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L786-786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L786-786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="266">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L786-786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L786-786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="267">
             <strong>Signature:</strong> unit -&gt; CellColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L790-790" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L790-790" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="268">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L790-790" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L790-790" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="269">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L794-794" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L794-794" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -350,10 +351,10 @@
           </code>
           <div class="tip" id="270">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L794-794" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L794-794" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="271">
             <strong>Signature:</strong> unit -&gt; CellColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L798-798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L798-798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -388,10 +389,10 @@
           </code>
           <div class="tip" id="272">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L798-798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L798-798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="273">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L814-814" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L814-814" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -425,10 +426,10 @@
           </code>
           <div class="tip" id="274">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L815-815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L815-815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,10 +444,10 @@
           </code>
           <div class="tip" id="275">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L816-816" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L816-816" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="276">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L817-817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L817-817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -479,10 +480,10 @@
           </code>
           <div class="tip" id="277">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L818-818" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L818-818" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +498,10 @@
           </code>
           <div class="tip" id="278">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L819-819" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L819-819" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="279">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L820-820" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L820-820" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="280">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L821-821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L821-821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +552,10 @@
           </code>
           <div class="tip" id="281">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L822-822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L822-822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -569,10 +570,10 @@
           </code>
           <div class="tip" id="282">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L823-823" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L823-823" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -587,10 +588,10 @@
           </code>
           <div class="tip" id="283">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L824-824" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L824-824" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -605,10 +606,10 @@
           </code>
           <div class="tip" id="284">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L802-802" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L802-802" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -624,10 +625,10 @@
           </code>
           <div class="tip" id="285">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L802-802" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L802-802" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -643,10 +644,10 @@
           </code>
           <div class="tip" id="286">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L806-806" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L806-806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="287">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L806-806" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L806-806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -681,10 +682,10 @@
           </code>
           <div class="tip" id="288">
             <strong>Signature:</strong> unit -&gt; CellColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L810-810" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L810-810" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -700,10 +701,10 @@
           </code>
           <div class="tip" id="289">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L810-810" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L810-810" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -723,7 +724,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -786,6 +787,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-candlecolor.html
+++ b/docs/reference/xplot-googlecharts-configuration-candlecolor.html
@@ -5,7 +5,7 @@
     <title>CandleColor - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>CandleColor</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="290">
             <strong>Signature:</strong> unit -&gt; CandleColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L540-540" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L540-540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="291">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L546-546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L546-546" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="292">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L546-546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L546-546" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="293">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L558-558" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L558-558" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -159,10 +160,10 @@
           </code>
           <div class="tip" id="294">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L559-559" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L559-559" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,10 +178,10 @@
           </code>
           <div class="tip" id="295">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L560-560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L560-560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="296">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L550-550" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L550-550" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="297">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L550-550" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L550-550" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="298">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L554-554" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L554-554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="299">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L554-554" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L554-554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-candlestick.html
+++ b/docs/reference/xplot-googlecharts-configuration-candlestick.html
@@ -5,7 +5,7 @@
     <title>Candlestick - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Candlestick</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="300">
             <strong>Signature:</strong> unit -&gt; Candlestick<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L842-842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L842-842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="301">
             <strong>Signature:</strong> unit -&gt; CandleColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L852-852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L852-852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="302">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L852-852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L852-852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="303">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L848-848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L848-848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="304">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L848-848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L848-848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="305">
             <strong>Signature:</strong> unit -&gt; CandleColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L856-856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L856-856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="306">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L856-856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L856-856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="307">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L861-861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L861-861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="308">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L860-860" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L860-860" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="309">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L862-862" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L862-862" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-cellcolor.html
+++ b/docs/reference/xplot-googlecharts-configuration-cellcolor.html
@@ -5,7 +5,7 @@
     <title>CellColor - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>CellColor</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="310">
             <strong>Signature:</strong> unit -&gt; CellColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L734-734" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L734-734" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="311">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L752-752" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L752-752" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="312">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L753-753" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L753-753" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="313">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L754-754" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L754-754" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="314">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L740-740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L740-740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -176,10 +177,10 @@
           </code>
           <div class="tip" id="315">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L740-740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L740-740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="316">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L744-744" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L744-744" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="317">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L744-744" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L744-744" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="318">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L748-748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L748-748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="319">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L748-748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L748-748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-chartarea.html
+++ b/docs/reference/xplot-googlecharts-configuration-chartarea.html
@@ -5,7 +5,7 @@
     <title>ChartArea - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>ChartArea</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="320">
             <strong>Signature:</strong> unit -&gt; ChartArea<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L200-200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L200-200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="321">
             <strong>Signature:</strong> unit -&gt; BackgroundColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L208-208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L208-208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="322">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L208-208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L208-208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="323">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L224-224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L224-224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="324">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L224-224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L224-224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="325">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L212-212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="326">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L212-212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="327">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L228-228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L228-228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="328">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L232-232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L232-232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="329">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L229-229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L229-229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="330">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L230-230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L230-230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="331">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L231-231" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L231-231" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -307,10 +308,10 @@
           </code>
           <div class="tip" id="332">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L216-216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L216-216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="333">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L216-216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L216-216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="334">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="335">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-classnames.html
+++ b/docs/reference/xplot-googlecharts-configuration-classnames.html
@@ -5,7 +5,7 @@
     <title>ClassNames - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>ClassNames</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="336">
             <strong>Signature:</strong> unit -&gt; ClassNames<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1205-1205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1205-1205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="337">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1236-1236" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1236-1236" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="338">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1236-1236" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1236-1236" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="339">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1216-1216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1216-1216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="340">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1216-1216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1216-1216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="341">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1232-1232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1232-1232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="342">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1232-1232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1232-1232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="343">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1224-1224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1224-1224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="344">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1224-1224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1224-1224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="345">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1244-1244" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1244-1244" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="346">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1244-1244" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1244-1244" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="347">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1228-1228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1228-1228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="348">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1228-1228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1228-1228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="349">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1253-1253" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1253-1253" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -349,10 +350,10 @@
           </code>
           <div class="tip" id="350">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1248-1248" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1248-1248" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -367,10 +368,10 @@
           </code>
           <div class="tip" id="351">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1252-1252" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1252-1252" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -385,10 +386,10 @@
           </code>
           <div class="tip" id="352">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1250-1250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1250-1250" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -403,10 +404,10 @@
           </code>
           <div class="tip" id="353">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1255-1255" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1255-1255" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -421,10 +422,10 @@
           </code>
           <div class="tip" id="354">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1251-1251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1251-1251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="355">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1254-1254" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1254-1254" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="356">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1249-1249" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1249-1249" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -475,10 +476,10 @@
           </code>
           <div class="tip" id="357">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1240-1240" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1240-1240" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="358">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1240-1240" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1240-1240" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -513,10 +514,10 @@
           </code>
           <div class="tip" id="359">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1220-1220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1220-1220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -532,10 +533,10 @@
           </code>
           <div class="tip" id="360">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1220-1220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1220-1220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -555,7 +556,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -618,6 +619,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-color.html
+++ b/docs/reference/xplot-googlecharts-configuration-color.html
@@ -5,7 +5,7 @@
     <title>Color - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Color</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="361">
             <strong>Signature:</strong> unit -&gt; Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L952-952" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L952-952" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="362">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L959-959" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L959-959" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="363">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L959-959" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L959-959" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="364">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L963-963" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L963-963" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="365">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L963-963" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L963-963" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="366">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L975-975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L975-975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="367">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L976-976" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L976-976" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -215,10 +216,10 @@
           </code>
           <div class="tip" id="368">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L977-977" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L977-977" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="369">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L978-978" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L978-978" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -251,10 +252,10 @@
           </code>
           <div class="tip" id="370">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L967-967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L967-967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -270,10 +271,10 @@
           </code>
           <div class="tip" id="371">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L967-967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L967-967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="372">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L971-971" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L971-971" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -308,10 +309,10 @@
           </code>
           <div class="tip" id="373">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L971-971" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L971-971" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,7 +332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -394,6 +395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-coloraxis.html
+++ b/docs/reference/xplot-googlecharts-configuration-coloraxis.html
@@ -5,7 +5,7 @@
     <title>ColorAxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>ColorAxis</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="374">
             <strong>Signature:</strong> unit -&gt; ColorAxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L700-700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L700-700" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="375">
             <strong>Signature:</strong> unit -&gt; string []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L720-720" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L720-720" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="376">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L720-720" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L720-720" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="377">
             <strong>Signature:</strong> unit -&gt; Legend<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L724-724" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L724-724" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="378">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L724-724" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L724-724" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="379">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L712-712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L712-712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="380">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L712-712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L712-712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="381">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L708-708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L708-708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="382">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L708-708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L708-708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="383">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L731-731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L731-731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="384">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L732-732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L732-732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="385">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L729-729" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L729-729" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="386">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L728-728" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L728-728" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="387">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L730-730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L730-730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="388">
             <strong>Signature:</strong> unit -&gt; int []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L716-716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L716-716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="389">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L716-716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L716-716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-crosshair.html
+++ b/docs/reference/xplot-googlecharts-configuration-crosshair.html
@@ -5,7 +5,7 @@
     <title>Crosshair - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Crosshair</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="390">
             <strong>Signature:</strong> unit -&gt; Crosshair<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L252-252" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L252-252" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="391">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L261-261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L261-261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="392">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L261-261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L261-261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="393">
             <strong>Signature:</strong> unit -&gt; Focused<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L265-265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L265-265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="394">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L265-265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L265-265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="395">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L269-269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L269-269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="396">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L269-269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L269-269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="397">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L273-273" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L273-273" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="398">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L273-273" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L273-273" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="399">
             <strong>Signature:</strong> unit -&gt; Selected<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L277-277" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L277-277" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="400">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L277-277" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L277-277" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="401">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L285-285" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L285-285" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -311,10 +312,10 @@
           </code>
           <div class="tip" id="402">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L286-286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L286-286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -329,10 +330,10 @@
           </code>
           <div class="tip" id="403">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L287-287" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L287-287" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="404">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L288-288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L288-288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -365,10 +366,10 @@
           </code>
           <div class="tip" id="405">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L289-289" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L289-289" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -383,10 +384,10 @@
           </code>
           <div class="tip" id="406">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L290-290" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L290-290" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -401,10 +402,10 @@
           </code>
           <div class="tip" id="407">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L281-281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L281-281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -420,10 +421,10 @@
           </code>
           <div class="tip" id="408">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L281-281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L281-281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,7 +444,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -506,6 +507,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-explorer.html
+++ b/docs/reference/xplot-googlecharts-configuration-explorer.html
@@ -5,7 +5,7 @@
     <title>Explorer - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Explorer</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="409">
             <strong>Signature:</strong> unit -&gt; Explorer<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L292-292" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L292-292" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="410">
             <strong>Signature:</strong> unit -&gt; string []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L301-301" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L301-301" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="411">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L301-301" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L301-301" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="412">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L305-305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L305-305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="413">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L305-305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L305-305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="414">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L309-309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L309-309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="415">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L309-309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L309-309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="416">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L313-313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L313-313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="417">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L313-313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L313-313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="418">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L317-317" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L317-317" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="419">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L317-317" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L317-317" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="420">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L325-325" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L325-325" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -311,10 +312,10 @@
           </code>
           <div class="tip" id="421">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L326-326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L326-326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -329,10 +330,10 @@
           </code>
           <div class="tip" id="422">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L327-327" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L327-327" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="423">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L328-328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L328-328" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -365,10 +366,10 @@
           </code>
           <div class="tip" id="424">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L329-329" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L329-329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -383,10 +384,10 @@
           </code>
           <div class="tip" id="425">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L330-330" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L330-330" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -401,10 +402,10 @@
           </code>
           <div class="tip" id="426">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L321-321" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L321-321" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -420,10 +421,10 @@
           </code>
           <div class="tip" id="427">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L321-321" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L321-321" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,7 +444,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -506,6 +507,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-focused.html
+++ b/docs/reference/xplot-googlecharts-configuration-focused.html
@@ -5,7 +5,7 @@
     <title>Focused - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Focused</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="428">
             <strong>Signature:</strong> unit -&gt; Focused<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L234-234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L234-234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="429">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="430">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="431">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="432">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="433">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L247-247" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L247-247" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="434">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L248-248" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L248-248" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-gradient.html
+++ b/docs/reference/xplot-googlecharts-configuration-gradient.html
@@ -5,7 +5,7 @@
     <title>Gradient - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Gradient</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="435">
             <strong>Signature:</strong> unit -&gt; Gradient<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L24-24" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L24-24" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="436">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L34-34" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L34-34" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="437">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L34-34" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L34-34" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="438">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L38-38" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L38-38" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="439">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L38-38" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L38-38" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="440">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L62-62" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L62-62" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="441">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L63-63" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L63-63" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -215,10 +216,10 @@
           </code>
           <div class="tip" id="442">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="443">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -251,10 +252,10 @@
           </code>
           <div class="tip" id="444">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L66-66" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L66-66" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -269,10 +270,10 @@
           </code>
           <div class="tip" id="445">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L65-65" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L65-65" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -287,10 +288,10 @@
           </code>
           <div class="tip" id="446">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L67-67" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L67-67" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="447">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L58-58" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L58-58" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -324,10 +325,10 @@
           </code>
           <div class="tip" id="448">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L58-58" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L58-58" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -343,10 +344,10 @@
           </code>
           <div class="tip" id="449">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L42-42" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L42-42" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -362,10 +363,10 @@
           </code>
           <div class="tip" id="450">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L42-42" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L42-42" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -381,10 +382,10 @@
           </code>
           <div class="tip" id="451">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L50-50" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L50-50" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -400,10 +401,10 @@
           </code>
           <div class="tip" id="452">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L50-50" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L50-50" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -419,10 +420,10 @@
           </code>
           <div class="tip" id="453">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L46-46" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -438,10 +439,10 @@
           </code>
           <div class="tip" id="454">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L46-46" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="455">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -476,10 +477,10 @@
           </code>
           <div class="tip" id="456">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,7 +500,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -562,6 +563,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-gridlines.html
+++ b/docs/reference/xplot-googlecharts-configuration-gridlines.html
@@ -5,7 +5,7 @@
     <title>Gridlines - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Gridlines</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="457">
             <strong>Signature:</strong> unit -&gt; Gridlines<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L332-332" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L332-332" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="458">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L337-337" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L337-337" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="459">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L337-337" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L337-337" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="460">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L341-341" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L341-341" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="461">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L341-341" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L341-341" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="462">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L345-345" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L345-345" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="463">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L346-346" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L346-346" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-histogram.html
+++ b/docs/reference/xplot-googlecharts-configuration-histogram.html
@@ -5,7 +5,7 @@
     <title>Histogram - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Histogram</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="464">
             <strong>Signature:</strong> unit -&gt; Histogram<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L908-908" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L908-908" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="465">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L914-914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L914-914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="466">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L914-914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L914-914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="467">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L918-918" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L918-918" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="468">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L918-918" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L918-918" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="469">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L922-922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L922-922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="470">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L922-922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L922-922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="471">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L926-926" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L926-926" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="472">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L927-927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L927-927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="473">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L928-928" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L928-928" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-label.html
+++ b/docs/reference/xplot-googlecharts-configuration-label.html
@@ -5,7 +5,7 @@
     <title>Label - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Label</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="474">
             <strong>Signature:</strong> unit -&gt; Label<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L980-980" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L980-980" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="475">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1000-1000" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1000-1000" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="476">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1000-1000" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1000-1000" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="477">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L996-996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L996-996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="478">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L996-996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L996-996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="479">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L988-988" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L988-988" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="480">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L988-988" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L988-988" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="481">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L992-992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L992-992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="482">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L992-992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L992-992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="483">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1004-1004" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1004-1004" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="484">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1004-1004" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1004-1004" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="485">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1011-1011" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1011-1011" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -311,10 +312,10 @@
           </code>
           <div class="tip" id="486">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1010-1010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1010-1010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -329,10 +330,10 @@
           </code>
           <div class="tip" id="487">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1008-1008" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1008-1008" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="488">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1009-1009" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1009-1009" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -365,10 +366,10 @@
           </code>
           <div class="tip" id="489">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1012-1012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1012-1012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-labelstyle.html
+++ b/docs/reference/xplot-googlecharts-configuration-labelstyle.html
@@ -5,7 +5,7 @@
     <title>LabelStyle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>LabelStyle</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="490">
             <strong>Signature:</strong> unit -&gt; LabelStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1137-1137" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1137-1137" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="491">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1143-1143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1143-1143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="492">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1143-1143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1143-1143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="493">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1147-1147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1147-1147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="494">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1147-1147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1147-1147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="495">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1151-1151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1151-1151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="496">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1151-1151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1151-1151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="497">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1155-1155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1155-1155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="498">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1156-1156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1156-1156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="499">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1157-1157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1157-1157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-legend.html
+++ b/docs/reference/xplot-googlecharts-configuration-legend.html
@@ -5,7 +5,7 @@
     <title>Legend - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Legend</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="500">
             <strong>Signature:</strong> unit -&gt; Legend<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L506-506" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L506-506" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="501">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L514-514" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L514-514" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="502">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L514-514" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L514-514" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="503">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L518-518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L518-518" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="504">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L518-518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L518-518" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="505">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L530-530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L530-530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="506">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L530-530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L530-530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="507">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L522-522" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L522-522" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="508">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L522-522" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L522-522" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="509">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L534-534" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L534-534" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="510">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L535-535" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L535-535" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="511">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L538-538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L538-538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="512">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L536-536" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L536-536" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="513">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L537-537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L537-537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="514">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L526-526" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L526-526" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="515">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L526-526" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L526-526" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-link.html
+++ b/docs/reference/xplot-googlecharts-configuration-link.html
@@ -5,7 +5,7 @@
     <title>Link - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Link</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="516">
             <strong>Signature:</strong> unit -&gt; Link<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1048-1048" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1048-1048" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="517">
             <strong>Signature:</strong> unit -&gt; Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1051-1051" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1051-1051" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="518">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1051-1051" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1051-1051" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="519">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1055-1055" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1055-1055" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,7 +164,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -226,6 +227,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-magnifyingglass.html
+++ b/docs/reference/xplot-googlecharts-configuration-magnifyingglass.html
@@ -5,7 +5,7 @@
     <title>MagnifyingGlass - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>MagnifyingGlass</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="520">
             <strong>Signature:</strong> unit -&gt; MagnifyingGlass<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L864-864" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L864-864" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="521">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L869-869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L869-869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="522">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L869-869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L869-869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="523">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L877-877" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L877-877" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -159,10 +160,10 @@
           </code>
           <div class="tip" id="524">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L878-878" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L878-878" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,10 +178,10 @@
           </code>
           <div class="tip" id="525">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L873-873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L873-873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -196,10 +197,10 @@
           </code>
           <div class="tip" id="526">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L873-873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L873-873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-nodatapattern.html
+++ b/docs/reference/xplot-googlecharts-configuration-nodatapattern.html
@@ -5,7 +5,7 @@
     <title>NoDataPattern - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>NoDataPattern</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="527">
             <strong>Signature:</strong> unit -&gt; NoDataPattern<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L826-826" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L826-826" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="528">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L831-831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L831-831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="529">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L831-831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L831-831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="530">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L835-835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L835-835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="531">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L835-835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L835-835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="532">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L839-839" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L839-839" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="533">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L840-840" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L840-840" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-node.html
+++ b/docs/reference/xplot-googlecharts-configuration-node.html
@@ -5,7 +5,7 @@
     <title>Node - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Node</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="534">
             <strong>Signature:</strong> unit -&gt; Node<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1014-1014" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1014-1014" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="535">
             <strong>Signature:</strong> unit -&gt; Color<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1022-1022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1022-1022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="536">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1022-1022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1022-1022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="537">
             <strong>Signature:</strong> unit -&gt; Label<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1026-1026" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1026-1026" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="538">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1026-1026" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1026-1026" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="539">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1030-1030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1030-1030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="540">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1030-1030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1030-1030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="541">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1034-1034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1034-1034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="542">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1034-1034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1034-1034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="543">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1042-1042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1042-1042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="544">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1043-1043" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1043-1043" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="545">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1044-1044" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1044-1044" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="546">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1045-1045" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1045-1045" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="547">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1046-1046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1046-1046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="548">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1038-1038" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1038-1038" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="549">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1038-1038" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1038-1038" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-numberformat.html
+++ b/docs/reference/xplot-googlecharts-configuration-numberformat.html
@@ -5,7 +5,7 @@
     <title>NumberFormat - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>NumberFormat</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 <p>Corresponds to the Google Charts NumberFormat type:
 <a href="https://developers.google.com/chart/interactive/docs/reference#numberformat">https://developers.google.com/chart/interactive/docs/reference#numberformat</a></p>
@@ -79,10 +80,10 @@
           </code>
           <div class="tip" id="550">
             <strong>Signature:</strong> unit -&gt; NumberFormat<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1259-1259" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1259-1259" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -106,10 +107,10 @@
           </code>
           <div class="tip" id="551">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1270-1270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1270-1270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -125,10 +126,10 @@
           </code>
           <div class="tip" id="552">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1270-1270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1270-1270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -144,10 +145,10 @@
           </code>
           <div class="tip" id="553">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1274-1274" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1274-1274" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,10 +164,10 @@
           </code>
           <div class="tip" id="554">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1274-1274" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1274-1274" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -182,10 +183,10 @@
           </code>
           <div class="tip" id="555">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1278-1278" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1278-1278" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="556">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1278-1278" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1278-1278" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -220,10 +221,10 @@
           </code>
           <div class="tip" id="557">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1282-1282" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1282-1282" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -239,10 +240,10 @@
           </code>
           <div class="tip" id="558">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1282-1282" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1282-1282" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -258,10 +259,10 @@
           </code>
           <div class="tip" id="559">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1286-1286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1286-1286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -277,10 +278,10 @@
           </code>
           <div class="tip" id="560">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1286-1286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1286-1286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -296,10 +297,10 @@
           </code>
           <div class="tip" id="561">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1290-1290" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1290-1290" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -315,10 +316,10 @@
           </code>
           <div class="tip" id="562">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1290-1290" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1290-1290" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="563">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1294-1294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1294-1294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -353,10 +354,10 @@
           </code>
           <div class="tip" id="564">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1294-1294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1294-1294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="565">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1302-1302" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1302-1302" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -390,10 +391,10 @@
           </code>
           <div class="tip" id="566">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1303-1303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1303-1303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -408,10 +409,10 @@
           </code>
           <div class="tip" id="567">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1304-1304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1304-1304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -426,10 +427,10 @@
           </code>
           <div class="tip" id="568">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1305-1305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1305-1305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -444,10 +445,10 @@
           </code>
           <div class="tip" id="569">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1306-1306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1306-1306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -462,10 +463,10 @@
           </code>
           <div class="tip" id="570">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1307-1307" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1307-1307" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -480,10 +481,10 @@
           </code>
           <div class="tip" id="571">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1308-1308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1308-1308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -498,10 +499,10 @@
           </code>
           <div class="tip" id="572">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1309-1309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1309-1309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -516,10 +517,10 @@
           </code>
           <div class="tip" id="573">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1298-1298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1298-1298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -535,10 +536,10 @@
           </code>
           <div class="tip" id="574">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1298-1298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1298-1298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -558,7 +559,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -621,6 +622,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-options.html
+++ b/docs/reference/xplot-googlecharts-configuration-options.html
@@ -5,7 +5,7 @@
     <title>Options - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Options</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="575">
             <strong>Signature:</strong> unit -&gt; Options<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1311-1311" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1311-1311" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="576">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1477-1477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1477-1477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="577">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1477-1477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1477-1477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="578">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1624-1624" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1624-1624" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="579">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1624-1624" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1624-1624" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="580">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1628-1628" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1628-1628" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="581">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1628-1628" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1628-1628" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="582">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1917-1917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1917-1917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="583">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1917-1917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1917-1917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="584">
             <strong>Signature:</strong> unit -&gt; Animation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1481-1481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1481-1481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="585">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1481-1481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1481-1481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="586">
             <strong>Signature:</strong> unit -&gt; Annotations<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1485-1485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1485-1485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="587">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1485-1485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1485-1485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="588">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1632-1632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1632-1632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -350,10 +351,10 @@
           </code>
           <div class="tip" id="589">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1632-1632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1632-1632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="590">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1489-1489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1489-1489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -388,10 +389,10 @@
           </code>
           <div class="tip" id="591">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1489-1489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1489-1489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="592">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1965-1965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1965-1965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -426,10 +427,10 @@
           </code>
           <div class="tip" id="593">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1965-1965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1965-1965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -445,10 +446,10 @@
           </code>
           <div class="tip" id="594">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1493-1493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1493-1493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -464,10 +465,10 @@
           </code>
           <div class="tip" id="595">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1493-1493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1493-1493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -483,10 +484,10 @@
           </code>
           <div class="tip" id="596">
             <strong>Signature:</strong> unit -&gt; BackgroundColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1497-1497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1497-1497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="597">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1497-1497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1497-1497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -521,10 +522,10 @@
           </code>
           <div class="tip" id="598">
             <strong>Signature:</strong> unit -&gt; Bar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1716-1716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1716-1716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -540,10 +541,10 @@
           </code>
           <div class="tip" id="599">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1716-1716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1716-1716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -559,10 +560,10 @@
           </code>
           <div class="tip" id="600">
             <strong>Signature:</strong> unit -&gt; Bubble<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1720-1720" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1720-1720" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="601">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1720-1720" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1720-1720" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -597,10 +598,10 @@
           </code>
           <div class="tip" id="602">
             <strong>Signature:</strong> unit -&gt; Calendar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1728-1728" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1728-1728" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -616,10 +617,10 @@
           </code>
           <div class="tip" id="603">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1728-1728" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1728-1728" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -635,10 +636,10 @@
           </code>
           <div class="tip" id="604">
             <strong>Signature:</strong> unit -&gt; Candlestick<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1736-1736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1736-1736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="605">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1736-1736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1736-1736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -673,10 +674,10 @@
           </code>
           <div class="tip" id="606">
             <strong>Signature:</strong> unit -&gt; ChartArea<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1501-1501" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1501-1501" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -692,10 +693,10 @@
           </code>
           <div class="tip" id="607">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1501-1501" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1501-1501" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -711,10 +712,10 @@
           </code>
           <div class="tip" id="608">
             <strong>Signature:</strong> unit -&gt; ColorAxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1724-1724" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1724-1724" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -730,10 +731,10 @@
           </code>
           <div class="tip" id="609">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1724-1724" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1724-1724" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -749,10 +750,10 @@
           </code>
           <div class="tip" id="610">
             <strong>Signature:</strong> unit -&gt; string []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1505-1505" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1505-1505" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -768,10 +769,10 @@
           </code>
           <div class="tip" id="611">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1505-1505" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1505-1505" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -787,10 +788,10 @@
           </code>
           <div class="tip" id="612">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1913-1913" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1913-1913" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -806,10 +807,10 @@
           </code>
           <div class="tip" id="613">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1913-1913" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1913-1913" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="614">
             <strong>Signature:</strong> unit -&gt; Crosshair<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1509-1509" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1509-1509" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -844,10 +845,10 @@
           </code>
           <div class="tip" id="615">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1509-1509" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1509-1509" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -863,10 +864,10 @@
           </code>
           <div class="tip" id="616">
             <strong>Signature:</strong> unit -&gt; ClassNames<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1921-1921" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1921-1921" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -882,10 +883,10 @@
           </code>
           <div class="tip" id="617">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1921-1921" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1921-1921" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -901,10 +902,10 @@
           </code>
           <div class="tip" id="618">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1740-1740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1740-1740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -920,10 +921,10 @@
           </code>
           <div class="tip" id="619">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1740-1740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1740-1740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -939,10 +940,10 @@
           </code>
           <div class="tip" id="620">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1793-1793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1793-1793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -958,10 +959,10 @@
           </code>
           <div class="tip" id="621">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1793-1793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1793-1793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -977,10 +978,10 @@
           </code>
           <div class="tip" id="622">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1513-1513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1513-1513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -996,10 +997,10 @@
           </code>
           <div class="tip" id="623">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1513-1513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1513-1513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1015,10 +1016,10 @@
           </code>
           <div class="tip" id="624">
             <strong>Signature:</strong> unit -&gt; (int * NumberFormat) list option<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1475-1475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1475-1475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1034,10 +1035,10 @@
           </code>
           <div class="tip" id="625">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1475-1475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1475-1475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1053,10 +1054,10 @@
           </code>
           <div class="tip" id="626">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1636-1636" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1636-1636" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1072,10 +1073,10 @@
           </code>
           <div class="tip" id="627">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1636-1636" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1636-1636" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1091,10 +1092,10 @@
           </code>
           <div class="tip" id="628">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1640-1640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1640-1640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1110,10 +1111,10 @@
           </code>
           <div class="tip" id="629">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1640-1640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1640-1640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1129,10 +1130,10 @@
           </code>
           <div class="tip" id="630">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1644-1644" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1644-1644" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1148,10 +1149,10 @@
           </code>
           <div class="tip" id="631">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1644-1644" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1644-1644" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1167,10 +1168,10 @@
           </code>
           <div class="tip" id="632">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1648-1648" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1648-1648" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1186,10 +1187,10 @@
           </code>
           <div class="tip" id="633">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1648-1648" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1648-1648" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1205,10 +1206,10 @@
           </code>
           <div class="tip" id="634">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1652-1652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1652-1652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1224,10 +1225,10 @@
           </code>
           <div class="tip" id="635">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1652-1652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1652-1652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1243,10 +1244,10 @@
           </code>
           <div class="tip" id="636">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1656-1656" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1656-1656" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1262,10 +1263,10 @@
           </code>
           <div class="tip" id="637">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1656-1656" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1656-1656" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1281,10 +1282,10 @@
           </code>
           <div class="tip" id="638">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1660-1660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1660-1660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1300,10 +1301,10 @@
           </code>
           <div class="tip" id="639">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1660-1660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1660-1660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1319,10 +1320,10 @@
           </code>
           <div class="tip" id="640">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1797-1797" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1797-1797" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1338,10 +1339,10 @@
           </code>
           <div class="tip" id="641">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1797-1797" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1797-1797" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1357,10 +1358,10 @@
           </code>
           <div class="tip" id="642">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1664-1664" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1664-1664" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1376,10 +1377,10 @@
           </code>
           <div class="tip" id="643">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1664-1664" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1664-1664" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1395,10 +1396,10 @@
           </code>
           <div class="tip" id="644">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1668-1668" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1668-1668" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1414,10 +1415,10 @@
           </code>
           <div class="tip" id="645">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1668-1668" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1668-1668" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1433,10 +1434,10 @@
           </code>
           <div class="tip" id="646">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1801-1801" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1801-1801" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1452,10 +1453,10 @@
           </code>
           <div class="tip" id="647">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1801-1801" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1801-1801" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1471,10 +1472,10 @@
           </code>
           <div class="tip" id="648">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1517-1517" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1517-1517" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1490,10 +1491,10 @@
           </code>
           <div class="tip" id="649">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1517-1517" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1517-1517" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1509,10 +1510,10 @@
           </code>
           <div class="tip" id="650">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1805-1805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1805-1805" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1528,10 +1529,10 @@
           </code>
           <div class="tip" id="651">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1805-1805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1805-1805" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1547,10 +1548,10 @@
           </code>
           <div class="tip" id="652">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1837-1837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1837-1837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1566,10 +1567,10 @@
           </code>
           <div class="tip" id="653">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1837-1837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1837-1837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1585,10 +1586,10 @@
           </code>
           <div class="tip" id="654">
             <strong>Signature:</strong> unit -&gt; Explorer<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1521-1521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1521-1521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1604,10 +1605,10 @@
           </code>
           <div class="tip" id="655">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1521-1521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1521-1521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1623,10 +1624,10 @@
           </code>
           <div class="tip" id="656">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1672-1672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1672-1672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1642,10 +1643,10 @@
           </code>
           <div class="tip" id="657">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1672-1672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1672-1672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1661,10 +1662,10 @@
           </code>
           <div class="tip" id="658">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1925-1925" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1925-1925" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1680,10 +1681,10 @@
           </code>
           <div class="tip" id="659">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1925-1925" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1925-1925" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1699,10 +1700,10 @@
           </code>
           <div class="tip" id="660">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1525-1525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1525-1525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1718,10 +1719,10 @@
           </code>
           <div class="tip" id="661">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1525-1525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1525-1525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1737,10 +1738,10 @@
           </code>
           <div class="tip" id="662">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1974-1974" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1974-1974" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1756,10 +1757,10 @@
           </code>
           <div class="tip" id="663">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1974-1974" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1974-1974" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1775,10 +1776,10 @@
           </code>
           <div class="tip" id="664">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1978-1978" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1978-1978" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1794,10 +1795,10 @@
           </code>
           <div class="tip" id="665">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1978-1978" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1978-1978" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1813,10 +1814,10 @@
           </code>
           <div class="tip" id="666">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1533-1533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1533-1533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1832,10 +1833,10 @@
           </code>
           <div class="tip" id="667">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1533-1533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1533-1533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1851,10 +1852,10 @@
           </code>
           <div class="tip" id="668">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1529-1529" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1529-1529" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1870,10 +1871,10 @@
           </code>
           <div class="tip" id="669">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1529-1529" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1529-1529" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1889,10 +1890,10 @@
           </code>
           <div class="tip" id="670">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1537-1537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1537-1537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1908,10 +1909,10 @@
           </code>
           <div class="tip" id="671">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1537-1537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1537-1537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1927,10 +1928,10 @@
           </code>
           <div class="tip" id="672">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1748-1748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1748-1748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1946,10 +1947,10 @@
           </code>
           <div class="tip" id="673">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1748-1748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1748-1748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1965,10 +1966,10 @@
           </code>
           <div class="tip" id="674">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1752-1752" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1752-1752" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1984,10 +1985,10 @@
           </code>
           <div class="tip" id="675">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1752-1752" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1752-1752" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2003,10 +2004,10 @@
           </code>
           <div class="tip" id="676">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1756-1756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1756-1756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2022,10 +2023,10 @@
           </code>
           <div class="tip" id="677">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1756-1756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1756-1756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2041,10 +2042,10 @@
           </code>
           <div class="tip" id="678">
             <strong>Signature:</strong> unit -&gt; Axis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1541-1541" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1541-1541" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2060,10 +2061,10 @@
           </code>
           <div class="tip" id="679">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1541-1541" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1541-1541" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2079,10 +2080,10 @@
           </code>
           <div class="tip" id="680">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1982-1982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1982-1982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2098,10 +2099,10 @@
           </code>
           <div class="tip" id="681">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1982-1982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1982-1982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2117,10 +2118,10 @@
           </code>
           <div class="tip" id="682">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1986-1986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1986-1986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2136,10 +2137,10 @@
           </code>
           <div class="tip" id="683">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1986-1986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1986-1986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2155,10 +2156,10 @@
           </code>
           <div class="tip" id="684">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1990-1990" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1990-1990" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2174,10 +2175,10 @@
           </code>
           <div class="tip" id="685">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1990-1990" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1990-1990" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2193,10 +2194,10 @@
           </code>
           <div class="tip" id="686">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1545-1545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1545-1545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2212,10 +2213,10 @@
           </code>
           <div class="tip" id="687">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1545-1545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1545-1545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2231,10 +2232,10 @@
           </code>
           <div class="tip" id="688">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1994-1994" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1994-1994" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2250,10 +2251,10 @@
           </code>
           <div class="tip" id="689">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1994-1994" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1994-1994" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2269,10 +2270,10 @@
           </code>
           <div class="tip" id="690">
             <strong>Signature:</strong> unit -&gt; Histogram<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1833-1833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1833-1833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2288,10 +2289,10 @@
           </code>
           <div class="tip" id="691">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1833-1833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1833-1833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2307,10 +2308,10 @@
           </code>
           <div class="tip" id="692">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1549-1549" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1549-1549" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2326,10 +2327,10 @@
           </code>
           <div class="tip" id="693">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1549-1549" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1549-1549" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2345,10 +2346,10 @@
           </code>
           <div class="tip" id="694">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1865-1865" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1865-1865" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2364,10 +2365,10 @@
           </code>
           <div class="tip" id="695">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1865-1865" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1865-1865" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2383,10 +2384,10 @@
           </code>
           <div class="tip" id="696">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1553-1553" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1553-1553" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2402,10 +2403,10 @@
           </code>
           <div class="tip" id="697">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1553-1553" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1553-1553" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2421,10 +2422,10 @@
           </code>
           <div class="tip" id="698">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1809-1809" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1809-1809" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2440,10 +2441,10 @@
           </code>
           <div class="tip" id="699">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1809-1809" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1809-1809" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2459,10 +2460,10 @@
           </code>
           <div class="tip" id="700">
             <strong>Signature:</strong> unit -&gt; Legend<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1557-1557" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1557-1557" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2478,10 +2479,10 @@
           </code>
           <div class="tip" id="701">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1557-1557" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1557-1557" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2497,10 +2498,10 @@
           </code>
           <div class="tip" id="702">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1676-1676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1676-1676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2516,10 +2517,10 @@
           </code>
           <div class="tip" id="703">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1676-1676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1676-1676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2535,10 +2536,10 @@
           </code>
           <div class="tip" id="704">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1849-1849" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1849-1849" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2554,10 +2555,10 @@
           </code>
           <div class="tip" id="705">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1849-1849" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1849-1849" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2573,10 +2574,10 @@
           </code>
           <div class="tip" id="706">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1561-1561" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1561-1561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2592,10 +2593,10 @@
           </code>
           <div class="tip" id="707">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1561-1561" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1561-1561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2611,10 +2612,10 @@
           </code>
           <div class="tip" id="708">
             <strong>Signature:</strong> unit -&gt; MagnifyingGlass<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1817-1817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1817-1817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2630,10 +2631,10 @@
           </code>
           <div class="tip" id="709">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1817-1817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1817-1817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2649,10 +2650,10 @@
           </code>
           <div class="tip" id="710">
             <strong>Signature:</strong> unit -&gt; string []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1761-1761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1761-1761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2668,10 +2669,10 @@
           </code>
           <div class="tip" id="711">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1761-1761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1761-1761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2687,10 +2688,10 @@
           </code>
           <div class="tip" id="712">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1853-1853" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1853-1853" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2706,10 +2707,10 @@
           </code>
           <div class="tip" id="713">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1853-1853" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1853-1853" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2725,10 +2726,10 @@
           </code>
           <div class="tip" id="714">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1821-1821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1821-1821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2744,10 +2745,10 @@
           </code>
           <div class="tip" id="715">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1821-1821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1821-1821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2763,10 +2764,10 @@
           </code>
           <div class="tip" id="716">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1680-1680" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1680-1680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2782,10 +2783,10 @@
           </code>
           <div class="tip" id="717">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1680-1680" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1680-1680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2801,10 +2802,10 @@
           </code>
           <div class="tip" id="718">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1998-1998" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1998-1998" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2820,10 +2821,10 @@
           </code>
           <div class="tip" id="719">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1998-1998" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1998-1998" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2839,10 +2840,10 @@
           </code>
           <div class="tip" id="720">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2014-2014" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2014-2014" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2858,10 +2859,10 @@
           </code>
           <div class="tip" id="721">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2014-2014" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2014-2014" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2877,10 +2878,10 @@
           </code>
           <div class="tip" id="722">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2002-2002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2002-2002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2896,10 +2897,10 @@
           </code>
           <div class="tip" id="723">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2002-2002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2002-2002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2915,10 +2916,10 @@
           </code>
           <div class="tip" id="724">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2006-2006" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2006-2006" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2934,10 +2935,10 @@
           </code>
           <div class="tip" id="725">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2006-2006" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2006-2006" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2953,10 +2954,10 @@
           </code>
           <div class="tip" id="726">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2010-2010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2010-2010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2972,10 +2973,10 @@
           </code>
           <div class="tip" id="727">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2010-2010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2010-2010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2991,10 +2992,10 @@
           </code>
           <div class="tip" id="728">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2018-2018" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2018-2018" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3010,10 +3011,10 @@
           </code>
           <div class="tip" id="729">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2018-2018" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2018-2018" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3029,10 +3030,10 @@
           </code>
           <div class="tip" id="730">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2022-2022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2022-2022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3048,10 +3049,10 @@
           </code>
           <div class="tip" id="731">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2022-2022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2022-2022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3067,10 +3068,10 @@
           </code>
           <div class="tip" id="732">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1684-1684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1684-1684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3086,10 +3087,10 @@
           </code>
           <div class="tip" id="733">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1684-1684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1684-1684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3105,10 +3106,10 @@
           </code>
           <div class="tip" id="734">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2026-2026" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2026-2026" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3124,10 +3125,10 @@
           </code>
           <div class="tip" id="735">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2026-2026" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2026-2026" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3143,10 +3144,10 @@
           </code>
           <div class="tip" id="736">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2034-2034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2034-2034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3162,10 +3163,10 @@
           </code>
           <div class="tip" id="737">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2034-2034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2034-2034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3181,10 +3182,10 @@
           </code>
           <div class="tip" id="738">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2030-2030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2030-2030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3200,10 +3201,10 @@
           </code>
           <div class="tip" id="739">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2030-2030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2030-2030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3219,10 +3220,10 @@
           </code>
           <div class="tip" id="740">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1765-1765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1765-1765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3238,10 +3239,10 @@
           </code>
           <div class="tip" id="741">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1765-1765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1765-1765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3257,10 +3258,10 @@
           </code>
           <div class="tip" id="742">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2038-2038" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2038-2038" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3276,10 +3277,10 @@
           </code>
           <div class="tip" id="743">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2038-2038" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2038-2038" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3295,10 +3296,10 @@
           </code>
           <div class="tip" id="744">
             <strong>Signature:</strong> unit -&gt; NoDataPattern<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1732-1732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1732-1732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3314,10 +3315,10 @@
           </code>
           <div class="tip" id="745">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1732-1732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1732-1732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3333,10 +3334,10 @@
           </code>
           <div class="tip" id="746">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2042-2042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2042-2042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3352,10 +3353,10 @@
           </code>
           <div class="tip" id="747">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2042-2042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2042-2042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3371,10 +3372,10 @@
           </code>
           <div class="tip" id="748">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1688-1688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1688-1688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3390,10 +3391,10 @@
           </code>
           <div class="tip" id="749">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1688-1688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1688-1688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3409,10 +3410,10 @@
           </code>
           <div class="tip" id="750">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1565-1565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1565-1565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3428,10 +3429,10 @@
           </code>
           <div class="tip" id="751">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1565-1565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1565-1565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3447,10 +3448,10 @@
           </code>
           <div class="tip" id="752">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1929-1929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1929-1929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3466,10 +3467,10 @@
           </code>
           <div class="tip" id="753">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1929-1929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1929-1929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3485,10 +3486,10 @@
           </code>
           <div class="tip" id="754">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1933-1933" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1933-1933" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3504,10 +3505,10 @@
           </code>
           <div class="tip" id="755">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1933-1933" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1933-1933" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3523,10 +3524,10 @@
           </code>
           <div class="tip" id="756">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1869-1869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1869-1869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3542,10 +3543,10 @@
           </code>
           <div class="tip" id="757">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1869-1869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1869-1869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3561,10 +3562,10 @@
           </code>
           <div class="tip" id="758">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1889-1889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1889-1889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3580,10 +3581,10 @@
           </code>
           <div class="tip" id="759">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1889-1889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1889-1889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3599,10 +3600,10 @@
           </code>
           <div class="tip" id="760">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1893-1893" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1893-1893" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3618,10 +3619,10 @@
           </code>
           <div class="tip" id="761">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1893-1893" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1893-1893" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3637,10 +3638,10 @@
           </code>
           <div class="tip" id="762">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1873-1873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1873-1873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3656,10 +3657,10 @@
           </code>
           <div class="tip" id="763">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1873-1873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1873-1873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3675,10 +3676,10 @@
           </code>
           <div class="tip" id="764">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1877-1877" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1877-1877" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3694,10 +3695,10 @@
           </code>
           <div class="tip" id="765">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1877-1877" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1877-1877" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3713,10 +3714,10 @@
           </code>
           <div class="tip" id="766">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1881-1881" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1881-1881" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3732,10 +3733,10 @@
           </code>
           <div class="tip" id="767">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1881-1881" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1881-1881" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3751,10 +3752,10 @@
           </code>
           <div class="tip" id="768">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1885-1885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1885-1885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3770,10 +3771,10 @@
           </code>
           <div class="tip" id="769">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1885-1885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1885-1885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3789,10 +3790,10 @@
           </code>
           <div class="tip" id="770">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1569-1569" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1569-1569" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3808,10 +3809,10 @@
           </code>
           <div class="tip" id="771">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1569-1569" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1569-1569" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3827,10 +3828,10 @@
           </code>
           <div class="tip" id="772">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1573-1573" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1573-1573" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3846,10 +3847,10 @@
           </code>
           <div class="tip" id="773">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1573-1573" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1573-1573" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3865,10 +3866,10 @@
           </code>
           <div class="tip" id="774">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1769-1769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1769-1769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3884,10 +3885,10 @@
           </code>
           <div class="tip" id="775">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1769-1769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1769-1769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3903,10 +3904,10 @@
           </code>
           <div class="tip" id="776">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1773-1773" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1773-1773" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3922,10 +3923,10 @@
           </code>
           <div class="tip" id="777">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1773-1773" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1773-1773" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3941,10 +3942,10 @@
           </code>
           <div class="tip" id="778">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1777-1777" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1777-1777" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3960,10 +3961,10 @@
           </code>
           <div class="tip" id="779">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1777-1777" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1777-1777" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3979,10 +3980,10 @@
           </code>
           <div class="tip" id="780">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1813-1813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1813-1813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3998,10 +3999,10 @@
           </code>
           <div class="tip" id="781">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1813-1813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1813-1813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4017,10 +4018,10 @@
           </code>
           <div class="tip" id="782">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1825-1825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1825-1825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4036,10 +4037,10 @@
           </code>
           <div class="tip" id="783">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1825-1825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1825-1825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4055,10 +4056,10 @@
           </code>
           <div class="tip" id="784">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1577-1577" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1577-1577" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4074,10 +4075,10 @@
           </code>
           <div class="tip" id="785">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1577-1577" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1577-1577" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4093,10 +4094,10 @@
           </code>
           <div class="tip" id="786">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1937-1937" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1937-1937" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4112,10 +4113,10 @@
           </code>
           <div class="tip" id="787">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1937-1937" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1937-1937" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4131,10 +4132,10 @@
           </code>
           <div class="tip" id="788">
             <strong>Signature:</strong> unit -&gt; Sankey<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1905-1905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1905-1905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4150,10 +4151,10 @@
           </code>
           <div class="tip" id="789">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1905-1905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1905-1905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4169,10 +4170,10 @@
           </code>
           <div class="tip" id="790">
             <strong>Signature:</strong> unit -&gt; int []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1692-1692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1692-1692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4188,10 +4189,10 @@
           </code>
           <div class="tip" id="791">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1692-1692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1692-1692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4207,10 +4208,10 @@
           </code>
           <div class="tip" id="792">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1696-1696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1696-1696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4226,10 +4227,10 @@
           </code>
           <div class="tip" id="793">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1696-1696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1696-1696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4245,10 +4246,10 @@
           </code>
           <div class="tip" id="794">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1700-1700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1700-1700" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4264,10 +4265,10 @@
           </code>
           <div class="tip" id="795">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1700-1700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1700-1700" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4283,10 +4284,10 @@
           </code>
           <div class="tip" id="796">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1941-1941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1941-1941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4302,10 +4303,10 @@
           </code>
           <div class="tip" id="797">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1941-1941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1941-1941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4321,10 +4322,10 @@
           </code>
           <div class="tip" id="798">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1581-1581" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1581-1581" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4340,10 +4341,10 @@
           </code>
           <div class="tip" id="799">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1581-1581" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1581-1581" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4359,10 +4360,10 @@
           </code>
           <div class="tip" id="800">
             <strong>Signature:</strong> unit -&gt; Series []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1585-1585" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1585-1585" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4378,10 +4379,10 @@
           </code>
           <div class="tip" id="801">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1585-1585" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1585-1585" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4397,10 +4398,10 @@
           </code>
           <div class="tip" id="802">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1744-1744" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1744-1744" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4416,10 +4417,10 @@
           </code>
           <div class="tip" id="803">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1744-1744" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1744-1744" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4435,10 +4436,10 @@
           </code>
           <div class="tip" id="804">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2058-2058" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2058-2058" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4453,10 +4454,10 @@
           </code>
           <div class="tip" id="805">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2094-2094" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2094-2094" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4471,10 +4472,10 @@
           </code>
           <div class="tip" id="806">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2095-2095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2095-2095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4489,10 +4490,10 @@
           </code>
           <div class="tip" id="807">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2167-2167" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2167-2167" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4507,10 +4508,10 @@
           </code>
           <div class="tip" id="808">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2059-2059" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2059-2059" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4525,10 +4526,10 @@
           </code>
           <div class="tip" id="809">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2060-2060" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2060-2060" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4543,10 +4544,10 @@
           </code>
           <div class="tip" id="810">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2096-2096" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2096-2096" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4561,10 +4562,10 @@
           </code>
           <div class="tip" id="811">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2061-2061" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2061-2061" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4579,10 +4580,10 @@
           </code>
           <div class="tip" id="812">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2179-2179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2179-2179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4597,10 +4598,10 @@
           </code>
           <div class="tip" id="813">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2062-2062" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2062-2062" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4615,10 +4616,10 @@
           </code>
           <div class="tip" id="814">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2063-2063" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2063-2063" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4633,10 +4634,10 @@
           </code>
           <div class="tip" id="815">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2117-2117" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2117-2117" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4651,10 +4652,10 @@
           </code>
           <div class="tip" id="816">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2118-2118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2118-2118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4669,10 +4670,10 @@
           </code>
           <div class="tip" id="817">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2120-2120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2120-2120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4687,10 +4688,10 @@
           </code>
           <div class="tip" id="818">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2122-2122" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2122-2122" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4705,10 +4706,10 @@
           </code>
           <div class="tip" id="819">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2064-2064" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2064-2064" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4723,10 +4724,10 @@
           </code>
           <div class="tip" id="820">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2119-2119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2119-2119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4741,10 +4742,10 @@
           </code>
           <div class="tip" id="821">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2065-2065" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2065-2065" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4759,10 +4760,10 @@
           </code>
           <div class="tip" id="822">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2166-2166" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2166-2166" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4777,10 +4778,10 @@
           </code>
           <div class="tip" id="823">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2066-2066" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2066-2066" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4795,10 +4796,10 @@
           </code>
           <div class="tip" id="824">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2168-2168" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2168-2168" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4813,10 +4814,10 @@
           </code>
           <div class="tip" id="825">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2123-2123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2123-2123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4831,10 +4832,10 @@
           </code>
           <div class="tip" id="826">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2136-2136" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2136-2136" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4849,10 +4850,10 @@
           </code>
           <div class="tip" id="827">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2067-2067" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2067-2067" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4867,10 +4868,10 @@
           </code>
           <div class="tip" id="828">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2202-2202" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2202-2202" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4885,10 +4886,10 @@
           </code>
           <div class="tip" id="829">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2097-2097" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2097-2097" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4903,10 +4904,10 @@
           </code>
           <div class="tip" id="830">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2098-2098" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2098-2098" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4921,10 +4922,10 @@
           </code>
           <div class="tip" id="831">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2099-2099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2099-2099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4939,10 +4940,10 @@
           </code>
           <div class="tip" id="832">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2100-2100" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2100-2100" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4957,10 +4958,10 @@
           </code>
           <div class="tip" id="833">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2101-2101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2101-2101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4975,10 +4976,10 @@
           </code>
           <div class="tip" id="834">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2102-2102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2102-2102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -4993,10 +4994,10 @@
           </code>
           <div class="tip" id="835">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2103-2103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2103-2103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5011,10 +5012,10 @@
           </code>
           <div class="tip" id="836">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2137-2137" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2137-2137" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5029,10 +5030,10 @@
           </code>
           <div class="tip" id="837">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2104-2104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2104-2104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5047,10 +5048,10 @@
           </code>
           <div class="tip" id="838">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2105-2105" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2105-2105" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5065,10 +5066,10 @@
           </code>
           <div class="tip" id="839">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2138-2138" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2138-2138" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5083,10 +5084,10 @@
           </code>
           <div class="tip" id="840">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2068-2068" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2068-2068" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5101,10 +5102,10 @@
           </code>
           <div class="tip" id="841">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2139-2139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2139-2139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5119,10 +5120,10 @@
           </code>
           <div class="tip" id="842">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2147-2147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2147-2147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5137,10 +5138,10 @@
           </code>
           <div class="tip" id="843">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2069-2069" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2069-2069" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5155,10 +5156,10 @@
           </code>
           <div class="tip" id="844">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2106-2106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2106-2106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5173,10 +5174,10 @@
           </code>
           <div class="tip" id="845">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2169-2169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2169-2169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5191,10 +5192,10 @@
           </code>
           <div class="tip" id="846">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2070-2070" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2070-2070" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5209,10 +5210,10 @@
           </code>
           <div class="tip" id="847">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2181-2181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2181-2181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5227,10 +5228,10 @@
           </code>
           <div class="tip" id="848">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2182-2182" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2182-2182" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5245,10 +5246,10 @@
           </code>
           <div class="tip" id="849">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2072-2072" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2072-2072" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5263,10 +5264,10 @@
           </code>
           <div class="tip" id="850">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2071-2071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2071-2071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5281,10 +5282,10 @@
           </code>
           <div class="tip" id="851">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2073-2073" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2073-2073" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5299,10 +5300,10 @@
           </code>
           <div class="tip" id="852">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2125-2125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2125-2125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5317,10 +5318,10 @@
           </code>
           <div class="tip" id="853">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2126-2126" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2126-2126" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5335,10 +5336,10 @@
           </code>
           <div class="tip" id="854">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2127-2127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2127-2127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5353,10 +5354,10 @@
           </code>
           <div class="tip" id="855">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2074-2074" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2074-2074" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5371,10 +5372,10 @@
           </code>
           <div class="tip" id="856">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2183-2183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2183-2183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5389,10 +5390,10 @@
           </code>
           <div class="tip" id="857">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2184-2184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2184-2184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5407,10 +5408,10 @@
           </code>
           <div class="tip" id="858">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2185-2185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2185-2185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5425,10 +5426,10 @@
           </code>
           <div class="tip" id="859">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2075-2075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2075-2075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5443,10 +5444,10 @@
           </code>
           <div class="tip" id="860">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2186-2186" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2186-2186" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5461,10 +5462,10 @@
           </code>
           <div class="tip" id="861">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2146-2146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2146-2146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5479,10 +5480,10 @@
           </code>
           <div class="tip" id="862">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2076-2076" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2076-2076" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5497,10 +5498,10 @@
           </code>
           <div class="tip" id="863">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2154-2154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2154-2154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5515,10 +5516,10 @@
           </code>
           <div class="tip" id="864">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2077-2077" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2077-2077" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5533,10 +5534,10 @@
           </code>
           <div class="tip" id="865">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2140-2140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2140-2140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5551,10 +5552,10 @@
           </code>
           <div class="tip" id="866">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2078-2078" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2078-2078" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5569,10 +5570,10 @@
           </code>
           <div class="tip" id="867">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2107-2107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2107-2107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5587,10 +5588,10 @@
           </code>
           <div class="tip" id="868">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2150-2150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2150-2150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5605,10 +5606,10 @@
           </code>
           <div class="tip" id="869">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2079-2079" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2079-2079" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5623,10 +5624,10 @@
           </code>
           <div class="tip" id="870">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2142-2142" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2142-2142" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5641,10 +5642,10 @@
           </code>
           <div class="tip" id="871">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2128-2128" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2128-2128" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5659,10 +5660,10 @@
           </code>
           <div class="tip" id="872">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2151-2151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2151-2151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5677,10 +5678,10 @@
           </code>
           <div class="tip" id="873">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2143-2143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2143-2143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5695,10 +5696,10 @@
           </code>
           <div class="tip" id="874">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2108-2108" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2108-2108" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5713,10 +5714,10 @@
           </code>
           <div class="tip" id="875">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2187-2187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2187-2187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5731,10 +5732,10 @@
           </code>
           <div class="tip" id="876">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2191-2191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2191-2191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5749,10 +5750,10 @@
           </code>
           <div class="tip" id="877">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2188-2188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2188-2188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5767,10 +5768,10 @@
           </code>
           <div class="tip" id="878">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2189-2189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2189-2189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5785,10 +5786,10 @@
           </code>
           <div class="tip" id="879">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2190-2190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2190-2190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5803,10 +5804,10 @@
           </code>
           <div class="tip" id="880">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2192-2192" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2192-2192" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5821,10 +5822,10 @@
           </code>
           <div class="tip" id="881">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2193-2193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2193-2193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5839,10 +5840,10 @@
           </code>
           <div class="tip" id="882">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2109-2109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2109-2109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5857,10 +5858,10 @@
           </code>
           <div class="tip" id="883">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2194-2194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2194-2194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5875,10 +5876,10 @@
           </code>
           <div class="tip" id="884">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2196-2196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2196-2196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5893,10 +5894,10 @@
           </code>
           <div class="tip" id="885">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2195-2195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2195-2195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5911,10 +5912,10 @@
           </code>
           <div class="tip" id="886">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2129-2129" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2129-2129" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5929,10 +5930,10 @@
           </code>
           <div class="tip" id="887">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2197-2197" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2197-2197" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5947,10 +5948,10 @@
           </code>
           <div class="tip" id="888">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2121-2121" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2121-2121" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5965,10 +5966,10 @@
           </code>
           <div class="tip" id="889">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2198-2198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2198-2198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -5983,10 +5984,10 @@
           </code>
           <div class="tip" id="890">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2110-2110" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2110-2110" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6001,10 +6002,10 @@
           </code>
           <div class="tip" id="891">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2080-2080" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2080-2080" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6019,10 +6020,10 @@
           </code>
           <div class="tip" id="892">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2170-2170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2170-2170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6037,10 +6038,10 @@
           </code>
           <div class="tip" id="893">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2171-2171" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2171-2171" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6055,10 +6056,10 @@
           </code>
           <div class="tip" id="894">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2155-2155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2155-2155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6073,10 +6074,10 @@
           </code>
           <div class="tip" id="895">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2160-2160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2160-2160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6091,10 +6092,10 @@
           </code>
           <div class="tip" id="896">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2161-2161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2161-2161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6109,10 +6110,10 @@
           </code>
           <div class="tip" id="897">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2156-2156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2156-2156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6127,10 +6128,10 @@
           </code>
           <div class="tip" id="898">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2157-2157" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2157-2157" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6145,10 +6146,10 @@
           </code>
           <div class="tip" id="899">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2158-2158" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2158-2158" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6163,10 +6164,10 @@
           </code>
           <div class="tip" id="900">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2159-2159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2159-2159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6181,10 +6182,10 @@
           </code>
           <div class="tip" id="901">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2081-2081" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2081-2081" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6199,10 +6200,10 @@
           </code>
           <div class="tip" id="902">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2082-2082" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2082-2082" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6217,10 +6218,10 @@
           </code>
           <div class="tip" id="903">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2130-2130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2130-2130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6235,10 +6236,10 @@
           </code>
           <div class="tip" id="904">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2131-2131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2131-2131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6253,10 +6254,10 @@
           </code>
           <div class="tip" id="905">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2132-2132" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2132-2132" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6271,10 +6272,10 @@
           </code>
           <div class="tip" id="906">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2141-2141" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2141-2141" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6289,10 +6290,10 @@
           </code>
           <div class="tip" id="907">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2144-2144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2144-2144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6307,10 +6308,10 @@
           </code>
           <div class="tip" id="908">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2083-2083" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2083-2083" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6325,10 +6326,10 @@
           </code>
           <div class="tip" id="909">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2172-2172" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2172-2172" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6343,10 +6344,10 @@
           </code>
           <div class="tip" id="910">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2164-2164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2164-2164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6361,10 +6362,10 @@
           </code>
           <div class="tip" id="911">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2111-2111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2111-2111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6379,10 +6380,10 @@
           </code>
           <div class="tip" id="912">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2112-2112" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2112-2112" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6397,10 +6398,10 @@
           </code>
           <div class="tip" id="913">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2113-2113" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2113-2113" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6415,10 +6416,10 @@
           </code>
           <div class="tip" id="914">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2173-2173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2173-2173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6433,10 +6434,10 @@
           </code>
           <div class="tip" id="915">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2084-2084" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2084-2084" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6451,10 +6452,10 @@
           </code>
           <div class="tip" id="916">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2085-2085" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2085-2085" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6469,10 +6470,10 @@
           </code>
           <div class="tip" id="917">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2124-2124" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2124-2124" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6487,10 +6488,10 @@
           </code>
           <div class="tip" id="918">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2149-2149" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2149-2149" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6505,10 +6506,10 @@
           </code>
           <div class="tip" id="919">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2174-2174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2174-2174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6523,10 +6524,10 @@
           </code>
           <div class="tip" id="920">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2199-2199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2199-2199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6541,10 +6542,10 @@
           </code>
           <div class="tip" id="921">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2148-2148" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2148-2148" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6559,10 +6560,10 @@
           </code>
           <div class="tip" id="922">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2200-2200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2200-2200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6577,10 +6578,10 @@
           </code>
           <div class="tip" id="923">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2145-2145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2145-2145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6595,10 +6596,10 @@
           </code>
           <div class="tip" id="924">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2162-2162" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2162-2162" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6613,10 +6614,10 @@
           </code>
           <div class="tip" id="925">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2163-2163" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2163-2163" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6631,10 +6632,10 @@
           </code>
           <div class="tip" id="926">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2175-2175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2175-2175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6649,10 +6650,10 @@
           </code>
           <div class="tip" id="927">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2176-2176" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2176-2176" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6667,10 +6668,10 @@
           </code>
           <div class="tip" id="928">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2177-2177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2177-2177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6685,10 +6686,10 @@
           </code>
           <div class="tip" id="929">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2178-2178" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2178-2178" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6703,10 +6704,10 @@
           </code>
           <div class="tip" id="930">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2086-2086" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2086-2086" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6721,10 +6722,10 @@
           </code>
           <div class="tip" id="931">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2114-2114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2114-2114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6739,10 +6740,10 @@
           </code>
           <div class="tip" id="932">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2180-2180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2180-2180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6757,10 +6758,10 @@
           </code>
           <div class="tip" id="933">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2087-2087" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2087-2087" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6775,10 +6776,10 @@
           </code>
           <div class="tip" id="934">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2088-2088" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2088-2088" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6793,10 +6794,10 @@
           </code>
           <div class="tip" id="935">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2089-2089" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2089-2089" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6811,10 +6812,10 @@
           </code>
           <div class="tip" id="936">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2090-2090" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2090-2090" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6829,10 +6830,10 @@
           </code>
           <div class="tip" id="937">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2165-2165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2165-2165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6847,10 +6848,10 @@
           </code>
           <div class="tip" id="938">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2152-2152" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2152-2152" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6865,10 +6866,10 @@
           </code>
           <div class="tip" id="939">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2201-2201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2201-2201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6883,10 +6884,10 @@
           </code>
           <div class="tip" id="940">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2091-2091" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2091-2091" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6901,10 +6902,10 @@
           </code>
           <div class="tip" id="941">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2092-2092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2092-2092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6919,10 +6920,10 @@
           </code>
           <div class="tip" id="942">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2093-2093" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2093-2093" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6937,10 +6938,10 @@
           </code>
           <div class="tip" id="943">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2133-2133" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2133-2133" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6955,10 +6956,10 @@
           </code>
           <div class="tip" id="944">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2134-2134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2134-2134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6973,10 +6974,10 @@
           </code>
           <div class="tip" id="945">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2135-2135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2135-2135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -6991,10 +6992,10 @@
           </code>
           <div class="tip" id="946">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2115-2115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2115-2115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7009,10 +7010,10 @@
           </code>
           <div class="tip" id="947">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2153-2153" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2153-2153" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7027,10 +7028,10 @@
           </code>
           <div class="tip" id="948">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2116-2116" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2116-2116" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7045,10 +7046,10 @@
           </code>
           <div class="tip" id="949">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1845-1845" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1845-1845" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7064,10 +7065,10 @@
           </code>
           <div class="tip" id="950">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1845-1845" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1845-1845" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7083,10 +7084,10 @@
           </code>
           <div class="tip" id="951">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1945-1945" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1945-1945" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7102,10 +7103,10 @@
           </code>
           <div class="tip" id="952">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1945-1945" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1945-1945" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7121,10 +7122,10 @@
           </code>
           <div class="tip" id="953">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2046-2046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2046-2046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7140,10 +7141,10 @@
           </code>
           <div class="tip" id="954">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2046-2046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2046-2046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7159,10 +7160,10 @@
           </code>
           <div class="tip" id="955">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1841-1841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1841-1841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7178,10 +7179,10 @@
           </code>
           <div class="tip" id="956">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1841-1841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1841-1841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7197,10 +7198,10 @@
           </code>
           <div class="tip" id="957">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2050-2050" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2050-2050" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7216,10 +7217,10 @@
           </code>
           <div class="tip" id="958">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2050-2050" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2050-2050" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7235,10 +7236,10 @@
           </code>
           <div class="tip" id="959">
             <strong>Signature:</strong> unit -&gt; SizeAxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1829-1829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1829-1829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7254,10 +7255,10 @@
           </code>
           <div class="tip" id="960">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1829-1829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1829-1829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7273,10 +7274,10 @@
           </code>
           <div class="tip" id="961">
             <strong>Signature:</strong> unit -&gt; Slice<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1897-1897" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1897-1897" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7292,10 +7293,10 @@
           </code>
           <div class="tip" id="962">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1897-1897" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1897-1897" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7311,10 +7312,10 @@
           </code>
           <div class="tip" id="963">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1901-1901" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1901-1901" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7330,10 +7331,10 @@
           </code>
           <div class="tip" id="964">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1901-1901" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1901-1901" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7349,10 +7350,10 @@
           </code>
           <div class="tip" id="965">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1949-1949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1949-1949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7368,10 +7369,10 @@
           </code>
           <div class="tip" id="966">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1949-1949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1949-1949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7387,10 +7388,10 @@
           </code>
           <div class="tip" id="967">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1953-1953" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1953-1953" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7406,10 +7407,10 @@
           </code>
           <div class="tip" id="968">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1953-1953" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1953-1953" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7425,10 +7426,10 @@
           </code>
           <div class="tip" id="969">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1957-1957" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1957-1957" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7444,10 +7445,10 @@
           </code>
           <div class="tip" id="970">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1957-1957" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1957-1957" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7463,10 +7464,10 @@
           </code>
           <div class="tip" id="971">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1961-1961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1961-1961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7482,10 +7483,10 @@
           </code>
           <div class="tip" id="972">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1961-1961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1961-1961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7501,10 +7502,10 @@
           </code>
           <div class="tip" id="973">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1589-1589" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1589-1589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7520,10 +7521,10 @@
           </code>
           <div class="tip" id="974">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1589-1589" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1589-1589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7539,10 +7540,10 @@
           </code>
           <div class="tip" id="975">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1704-1704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1704-1704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7558,10 +7559,10 @@
           </code>
           <div class="tip" id="976">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1704-1704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1704-1704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7577,10 +7578,10 @@
           </code>
           <div class="tip" id="977">
             <strong>Signature:</strong> unit -&gt; Timeline<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1969-1969" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1969-1969" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7596,10 +7597,10 @@
           </code>
           <div class="tip" id="978">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1969-1969" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1969-1969" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7615,10 +7616,10 @@
           </code>
           <div class="tip" id="979">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1593-1593" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1593-1593" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7634,10 +7635,10 @@
           </code>
           <div class="tip" id="980">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1593-1593" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1593-1593" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7653,10 +7654,10 @@
           </code>
           <div class="tip" id="981">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1600-1600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1600-1600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7672,10 +7673,10 @@
           </code>
           <div class="tip" id="982">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1600-1600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1600-1600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7691,10 +7692,10 @@
           </code>
           <div class="tip" id="983">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1604-1604" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1604-1604" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7710,10 +7711,10 @@
           </code>
           <div class="tip" id="984">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1604-1604" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1604-1604" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7729,10 +7730,10 @@
           </code>
           <div class="tip" id="985">
             <strong>Signature:</strong> unit -&gt; Tooltip<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1608-1608" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1608-1608" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7748,10 +7749,10 @@
           </code>
           <div class="tip" id="986">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1608-1608" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1608-1608" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7767,10 +7768,10 @@
           </code>
           <div class="tip" id="987">
             <strong>Signature:</strong> unit -&gt; Trendline []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1909-1909" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1909-1909" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7786,10 +7787,10 @@
           </code>
           <div class="tip" id="988">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1909-1909" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1909-1909" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7805,10 +7806,10 @@
           </code>
           <div class="tip" id="989">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1857-1857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1857-1857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7824,10 +7825,10 @@
           </code>
           <div class="tip" id="990">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1857-1857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1857-1857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7843,10 +7844,10 @@
           </code>
           <div class="tip" id="991">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2054-2054" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2054-2054" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7862,10 +7863,10 @@
           </code>
           <div class="tip" id="992">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2054-2054" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L2054-2054" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7881,10 +7882,10 @@
           </code>
           <div class="tip" id="993">
             <strong>Signature:</strong> unit -&gt; Axis []<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1612-1612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1612-1612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7900,10 +7901,10 @@
           </code>
           <div class="tip" id="994">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1612-1612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1612-1612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7919,10 +7920,10 @@
           </code>
           <div class="tip" id="995">
             <strong>Signature:</strong> unit -&gt; Axis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1616-1616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1616-1616" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7938,10 +7939,10 @@
           </code>
           <div class="tip" id="996">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1616-1616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1616-1616" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7957,10 +7958,10 @@
           </code>
           <div class="tip" id="997">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1620-1620" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1620-1620" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7976,10 +7977,10 @@
           </code>
           <div class="tip" id="998">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1620-1620" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1620-1620" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -7995,10 +7996,10 @@
           </code>
           <div class="tip" id="999">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1781-1781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1781-1781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8014,10 +8015,10 @@
           </code>
           <div class="tip" id="1000">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1781-1781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1781-1781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8033,10 +8034,10 @@
           </code>
           <div class="tip" id="1001">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1785-1785" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1785-1785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8052,10 +8053,10 @@
           </code>
           <div class="tip" id="1002">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1785-1785" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1785-1785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8071,10 +8072,10 @@
           </code>
           <div class="tip" id="1003">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1789-1789" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1789-1789" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8090,10 +8091,10 @@
           </code>
           <div class="tip" id="1004">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1789-1789" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1789-1789" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8109,10 +8110,10 @@
           </code>
           <div class="tip" id="1005">
             <strong>Signature:</strong> unit -&gt; DateTime<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1708-1708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1708-1708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8128,10 +8129,10 @@
           </code>
           <div class="tip" id="1006">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1708-1708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1708-1708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8147,10 +8148,10 @@
           </code>
           <div class="tip" id="1007">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1861-1861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1861-1861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8166,10 +8167,10 @@
           </code>
           <div class="tip" id="1008">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1861-1861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1861-1861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8185,10 +8186,10 @@
           </code>
           <div class="tip" id="1009">
             <strong>Signature:</strong> unit -&gt; DateTime<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1712-1712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1712-1712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8204,10 +8205,10 @@
           </code>
           <div class="tip" id="1010">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1712-1712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1712-1712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -8227,7 +8228,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -8290,6 +8291,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-sankey.html
+++ b/docs/reference/xplot-googlecharts-configuration-sankey.html
@@ -5,7 +5,7 @@
     <title>Sankey - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Sankey</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1011">
             <strong>Signature:</strong> unit -&gt; Sankey<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1057-1057" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1057-1057" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1012">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1063-1063" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1063-1063" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1013">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1063-1063" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1063-1063" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1014">
             <strong>Signature:</strong> unit -&gt; Link<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1067-1067" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1067-1067" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1015">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1067-1067" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1067-1067" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1016">
             <strong>Signature:</strong> unit -&gt; Node<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1071-1071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1071-1071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1017">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1071-1071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1071-1071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1018">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1075-1075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1075-1075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -235,10 +236,10 @@
           </code>
           <div class="tip" id="1019">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1076-1076" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1076-1076" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -253,10 +254,10 @@
           </code>
           <div class="tip" id="1020">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1077-1077" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1077-1077" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-selected.html
+++ b/docs/reference/xplot-googlecharts-configuration-selected.html
@@ -5,7 +5,7 @@
     <title>Selected - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Selected</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Instance members</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1021">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L239-239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -95,10 +96,10 @@
           </code>
           <div class="tip" id="1022">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L243-243" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -118,7 +119,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -181,6 +182,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-series.html
+++ b/docs/reference/xplot-googlecharts-configuration-series.html
@@ -5,7 +5,7 @@
     <title>Series - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Series</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1023">
             <strong>Signature:</strong> (type:string option) -&gt; Series<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L562-562" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L562-562" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1024">
             <strong>Signature:</strong> unit -&gt; Annotations<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L579-579" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L579-579" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1025">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L579-579" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L579-579" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1026">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L603-603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L603-603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1027">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L603-603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L603-603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1028">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L583-583" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L583-583" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1029">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L583-583" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L583-583" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1030">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L619-619" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L619-619" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="1031">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L619-619" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L619-619" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1032">
             <strong>Signature:</strong> unit -&gt; CandleColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L611-611" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L611-611" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="1033">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L611-611" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L611-611" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="1034">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L599-599" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L599-599" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="1035">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L599-599" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L599-599" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="1036">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L591-591" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L591-591" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -350,10 +351,10 @@
           </code>
           <div class="tip" id="1037">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L591-591" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L591-591" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="1038">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L595-595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L595-595" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -388,10 +389,10 @@
           </code>
           <div class="tip" id="1039">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L595-595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L595-595" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="1040">
             <strong>Signature:</strong> unit -&gt; CandleColor<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L615-615" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L615-615" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -426,10 +427,10 @@
           </code>
           <div class="tip" id="1041">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L615-615" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L615-615" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -445,10 +446,10 @@
           </code>
           <div class="tip" id="1042">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L627-627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L627-627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -463,10 +464,10 @@
           </code>
           <div class="tip" id="1043">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L633-633" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L633-633" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="1044">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L628-628" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L628-628" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,10 +500,10 @@
           </code>
           <div class="tip" id="1045">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L637-637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L637-637" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -517,10 +518,10 @@
           </code>
           <div class="tip" id="1046">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L635-635" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L635-635" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -535,10 +536,10 @@
           </code>
           <div class="tip" id="1047">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L632-632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L632-632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="1048">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L630-630" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L630-630" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -571,10 +572,10 @@
           </code>
           <div class="tip" id="1049">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L631-631" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L631-631" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -589,10 +590,10 @@
           </code>
           <div class="tip" id="1050">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L636-636" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L636-636" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -607,10 +608,10 @@
           </code>
           <div class="tip" id="1051">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L629-629" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L629-629" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -625,10 +626,10 @@
           </code>
           <div class="tip" id="1052">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L638-638" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L638-638" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -643,10 +644,10 @@
           </code>
           <div class="tip" id="1053">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L634-634" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L634-634" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -661,10 +662,10 @@
           </code>
           <div class="tip" id="1054">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L587-587" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L587-587" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -680,10 +681,10 @@
           </code>
           <div class="tip" id="1055">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L587-587" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L587-587" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -699,10 +700,10 @@
           </code>
           <div class="tip" id="1056">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L623-623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L623-623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -718,10 +719,10 @@
           </code>
           <div class="tip" id="1057">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L623-623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L623-623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -737,10 +738,10 @@
           </code>
           <div class="tip" id="1058">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L607-607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L607-607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -756,10 +757,10 @@
           </code>
           <div class="tip" id="1059">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L607-607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L607-607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -779,7 +780,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -842,6 +843,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-sizeaxis.html
+++ b/docs/reference/xplot-googlecharts-configuration-sizeaxis.html
@@ -5,7 +5,7 @@
     <title>SizeAxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>SizeAxis</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1060">
             <strong>Signature:</strong> unit -&gt; SizeAxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L880-880" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L880-880" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1061">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L887-887" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L887-887" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1062">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L887-887" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L887-887" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1063">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L891-891" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L891-891" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1064">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L891-891" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L891-891" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1065">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L895-895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L895-895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1066">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L895-895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L895-895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1067">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L899-899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L899-899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="1068">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L899-899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L899-899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1069">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L903-903" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L903-903" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="1070">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L904-904" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L904-904" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="1071">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L905-905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L905-905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="1072">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L906-906" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L906-906" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,7 +332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -394,6 +395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-slice.html
+++ b/docs/reference/xplot-googlecharts-configuration-slice.html
@@ -5,7 +5,7 @@
     <title>Slice - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Slice</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1073">
             <strong>Signature:</strong> unit -&gt; Slice<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L930-930" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L930-930" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1074">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L936-936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L936-936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1075">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L936-936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L936-936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1076">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L940-940" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L940-940" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1077">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L940-940" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L940-940" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1078">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L948-948" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L948-948" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="1079">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L949-949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L949-949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -215,10 +216,10 @@
           </code>
           <div class="tip" id="1080">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L950-950" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L950-950" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="1081">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L944-944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L944-944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="1082">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L944-944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L944-944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-textstyle.html
+++ b/docs/reference/xplot-googlecharts-configuration-textstyle.html
@@ -5,7 +5,7 @@
     <title>TextStyle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>TextStyle</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1083">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L104-104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L104-104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1084">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L134-134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L134-134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1085">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L134-134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L134-134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1086">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L122-122" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L122-122" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1087">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L122-122" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L122-122" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1088">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L130-130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L130-130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1089">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L130-130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L130-130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1090">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L114-114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L114-114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="1091">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L114-114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L114-114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1092">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L118-118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L118-118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="1093">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L118-118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L118-118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="1094">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L126-126" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L126-126" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="1095">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L126-126" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L126-126" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="1096">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L138-138" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L138-138" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -350,10 +351,10 @@
           </code>
           <div class="tip" id="1097">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L138-138" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L138-138" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="1098">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,10 +388,10 @@
           </code>
           <div class="tip" id="1099">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L144-144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L144-144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -405,10 +406,10 @@
           </code>
           <div class="tip" id="1100">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L146-146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L146-146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -423,10 +424,10 @@
           </code>
           <div class="tip" id="1101">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L142-142" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L142-142" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -441,10 +442,10 @@
           </code>
           <div class="tip" id="1102">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L143-143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L143-143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -459,10 +460,10 @@
           </code>
           <div class="tip" id="1103">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L145-145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L145-145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="1104">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L148-148" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L148-148" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,7 +500,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -562,6 +563,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-timeline.html
+++ b/docs/reference/xplot-googlecharts-configuration-timeline.html
@@ -5,7 +5,7 @@
     <title>Timeline - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Timeline</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1105">
             <strong>Signature:</strong> unit -&gt; Timeline<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1159-1159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1159-1159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1106">
             <strong>Signature:</strong> unit -&gt; LabelStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1169-1169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1169-1169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1107">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1169-1169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1169-1169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1108">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1173-1173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1173-1173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1109">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1173-1173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1173-1173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1110">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1177-1177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1177-1177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1111">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1177-1177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1177-1177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1112">
             <strong>Signature:</strong> unit -&gt; LabelStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1181-1181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1181-1181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="1113">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1181-1181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1181-1181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1114">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1197-1197" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1197-1197" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="1115">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1198-1198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1198-1198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="1116">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1199-1199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1199-1199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="1117">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1200-1200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1200-1200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="1118">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1201-1201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1201-1201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="1119">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1202-1202" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1202-1202" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -363,10 +364,10 @@
           </code>
           <div class="tip" id="1120">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1203-1203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1203-1203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -381,10 +382,10 @@
           </code>
           <div class="tip" id="1121">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1185-1185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1185-1185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -400,10 +401,10 @@
           </code>
           <div class="tip" id="1122">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1185-1185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1185-1185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -419,10 +420,10 @@
           </code>
           <div class="tip" id="1123">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1189-1189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1189-1189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -438,10 +439,10 @@
           </code>
           <div class="tip" id="1124">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1189-1189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1189-1189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="1125">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1193-1193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1193-1193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -476,10 +477,10 @@
           </code>
           <div class="tip" id="1126">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1193-1193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1193-1193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,7 +500,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -562,6 +563,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-tooltip.html
+++ b/docs/reference/xplot-googlecharts-configuration-tooltip.html
@@ -5,7 +5,7 @@
     <title>Tooltip - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Tooltip</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1127">
             <strong>Signature:</strong> unit -&gt; Tooltip<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L640-640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L640-640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1128">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L647-647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L647-647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1129">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L647-647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L647-647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1130">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L663-663" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L663-663" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -159,10 +160,10 @@
           </code>
           <div class="tip" id="1131">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L664-664" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L664-664" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -177,10 +178,10 @@
           </code>
           <div class="tip" id="1132">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L665-665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L665-665" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="1133">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L666-666" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L666-666" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -213,10 +214,10 @@
           </code>
           <div class="tip" id="1134">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L651-651" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L651-651" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -232,10 +233,10 @@
           </code>
           <div class="tip" id="1135">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L651-651" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L651-651" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -251,10 +252,10 @@
           </code>
           <div class="tip" id="1136">
             <strong>Signature:</strong> unit -&gt; TextStyle<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L655-655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L655-655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -270,10 +271,10 @@
           </code>
           <div class="tip" id="1137">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L655-655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L655-655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="1138">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L659-659" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L659-659" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -308,10 +309,10 @@
           </code>
           <div class="tip" id="1139">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L659-659" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L659-659" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,7 +332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -394,6 +395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-trendline.html
+++ b/docs/reference/xplot-googlecharts-configuration-trendline.html
@@ -5,7 +5,7 @@
     <title>Trendline - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Trendline</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1140">
             <strong>Signature:</strong> unit -&gt; Trendline<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1079-1079" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1079-1079" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1141">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1091-1091" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1091-1091" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1142">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1091-1091" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1091-1091" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1143">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1095-1095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1095-1095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1144">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1095-1095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1095-1095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1145">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1099-1099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1099-1099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="1146">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1099-1099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1099-1099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="1147">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1103-1103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1103-1103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="1148">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1103-1103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1103-1103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="1149">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1107-1107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1107-1107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -274,10 +275,10 @@
           </code>
           <div class="tip" id="1150">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1107-1107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1107-1107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -293,10 +294,10 @@
           </code>
           <div class="tip" id="1151">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1111-1111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1111-1111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +313,10 @@
           </code>
           <div class="tip" id="1152">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1111-1111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1111-1111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="1153">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1127-1127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1127-1127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -349,10 +350,10 @@
           </code>
           <div class="tip" id="1154">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1128-1128" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1128-1128" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -367,10 +368,10 @@
           </code>
           <div class="tip" id="1155">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1129-1129" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1129-1129" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -385,10 +386,10 @@
           </code>
           <div class="tip" id="1156">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1130-1130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1130-1130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -403,10 +404,10 @@
           </code>
           <div class="tip" id="1157">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1131-1131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1131-1131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -421,10 +422,10 @@
           </code>
           <div class="tip" id="1158">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1132-1132" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1132-1132" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="1159">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1133-1133" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1133-1133" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="1160">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1134-1134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1134-1134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -475,10 +476,10 @@
           </code>
           <div class="tip" id="1161">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1135-1135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1135-1135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -493,10 +494,10 @@
           </code>
           <div class="tip" id="1162">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1115-1115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1115-1115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -512,10 +513,10 @@
           </code>
           <div class="tip" id="1163">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1115-1115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1115-1115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -531,10 +532,10 @@
           </code>
           <div class="tip" id="1164">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1119-1119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1119-1119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -550,10 +551,10 @@
           </code>
           <div class="tip" id="1165">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1119-1119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1119-1119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -569,10 +570,10 @@
           </code>
           <div class="tip" id="1166">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1123-1123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1123-1123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -588,10 +589,10 @@
           </code>
           <div class="tip" id="1167">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1123-1123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L1123-1123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -611,7 +612,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -674,6 +675,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration-viewwindow.html
+++ b/docs/reference/xplot-googlecharts-configuration-viewwindow.html
@@ -5,7 +5,7 @@
     <title>ViewWindow - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>ViewWindow</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-configuration.html">Configuration</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1168">
             <strong>Signature:</strong> unit -&gt; ViewWindow<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L348-348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L348-348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1169">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L353-353" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L353-353" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1170">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L353-353" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L353-353" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1171">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L357-357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L357-357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1172">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L357-357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L357-357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1173">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L361-361" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L361-361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="1174">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L362-362" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Configuration.fs#L362-362" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-configuration.html
+++ b/docs/reference/xplot-googlecharts-configuration.html
@@ -5,7 +5,7 @@
     <title>Configuration - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Configuration</h1>
 <p>
   <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -74,244 +79,324 @@
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-animation.html">Animation</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-annotations.html">Annotations</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-axis.html">Axis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-backgroundcolor.html">BackgroundColor</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-bar.html">Bar</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-boxstyle.html">BoxStyle</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-bubble.html">Bubble</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-calendar.html">Calendar</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-candlecolor.html">CandleColor</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-candlestick.html">Candlestick</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-cellcolor.html">CellColor</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-chartarea.html">ChartArea</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-classnames.html">ClassNames</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-color.html">Color</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-coloraxis.html">ColorAxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-crosshair.html">Crosshair</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-explorer.html">Explorer</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-focused.html">Focused</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-gradient.html">Gradient</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-gridlines.html">Gridlines</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-histogram.html">Histogram</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-label.html">Label</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-labelstyle.html">LabelStyle</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-legend.html">Legend</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-link.html">Link</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-magnifyingglass.html">MagnifyingGlass</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-nodatapattern.html">NoDataPattern</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-node.html">Node</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-numberformat.html">NumberFormat</a>
           </td>
-          <td class="xmldoc"><p>Corresponds to the Google Charts NumberFormat type:
+          <td class="xmldoc">
+          <p>Corresponds to the Google Charts NumberFormat type:
 <a href="https://developers.google.com/chart/interactive/docs/reference#numberformat">https://developers.google.com/chart/interactive/docs/reference#numberformat</a></p>
 
-</td>
+
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-options.html">Options</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-sankey.html">Sankey</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-selected.html">Selected</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-series.html">Series</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-sizeaxis.html">SizeAxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-slice.html">Slice</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-textstyle.html">TextStyle</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-timeline.html">Timeline</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-tooltip.html">Tooltip</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-trendline.html">Trendline</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-configuration-viewwindow.html">ViewWindow</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -328,7 +413,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -391,6 +476,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-data-datum.html
+++ b/docs/reference/xplot-googlecharts-data-datum.html
@@ -5,7 +5,7 @@
     <title>Datum - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Datum</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-data.html">Data</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-data.html">Data</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1175">
             <strong>Signature:</strong> key<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L19-19" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L20-20" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="1176">
             <strong>Signature:</strong> value<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L20-20" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L21-21" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -112,10 +113,10 @@
           </code>
           <div class="tip" id="1177">
             <strong>Signature:</strong> value option<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L21-21" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L22-22" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -130,10 +131,10 @@
           </code>
           <div class="tip" id="1178">
             <strong>Signature:</strong> value option<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L22-22" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L23-23" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -148,10 +149,10 @@
           </code>
           <div class="tip" id="1179">
             <strong>Signature:</strong> value option<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L23-23" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L24-24" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -174,10 +175,10 @@
           </code>
           <div class="tip" id="1180">
             <strong>Signature:</strong> (x:key * y1:value * y2:value * y3:value * y4:value) -&gt; Datum<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L32-32" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L33-33" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -192,10 +193,10 @@
           </code>
           <div class="tip" id="1181">
             <strong>Signature:</strong> (x:key * y1:value * y2:value * y3:value) -&gt; Datum<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L30-30" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L31-31" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -210,10 +211,10 @@
           </code>
           <div class="tip" id="1182">
             <strong>Signature:</strong> (x:key * y1:value * y2:value) -&gt; Datum<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L28-28" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L29-29" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -228,10 +229,10 @@
           </code>
           <div class="tip" id="1183">
             <strong>Signature:</strong> (x:key * y:value) -&gt; Datum<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L26-26" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L27-27" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,7 +251,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -313,6 +314,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-data-series.html
+++ b/docs/reference/xplot-googlecharts-data-series.html
@@ -5,7 +5,7 @@
     <title>Series - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Series</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-  <span>Parent Module: <a href="xplot-googlecharts-data.html">Data</a></span>
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>Parent Module: <a href="xplot-googlecharts-data.html">Data</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1184">
             <strong>Signature:</strong> seq&lt;Datum&gt;<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L36-36" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L37-37" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -101,11 +102,11 @@
             New(data)
           </code>
           <div class="tip" id="1185">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7901 * &#39;?7902 * &#39;?7903 * &#39;?7904 * &#39;?7905&gt;) -&gt; Series<br />
-                          <strong>Type parameters:</strong> '?7901, '?7902, '?7903, '?7904, '?7905          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8266 * &#39;?8267 * &#39;?8268 * &#39;?8269 * &#39;?8270&gt;) -&gt; Series<br />
+                          <strong>Type parameters:</strong> '?8266, '?8267, '?8268, '?8269, '?8270                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L56-56" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L57-57" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -119,11 +120,11 @@
             New(data)
           </code>
           <div class="tip" id="1186">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7896 * &#39;?7897 * &#39;?7898 * &#39;?7899&gt;) -&gt; Series<br />
-                          <strong>Type parameters:</strong> '?7896, '?7897, '?7898, '?7899          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8261 * &#39;?8262 * &#39;?8263 * &#39;?8264&gt;) -&gt; Series<br />
+                          <strong>Type parameters:</strong> '?8261, '?8262, '?8263, '?8264                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L51-51" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L52-52" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -137,11 +138,11 @@
             New(data)
           </code>
           <div class="tip" id="1187">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7892 * &#39;?7893 * &#39;?7894&gt;) -&gt; Series<br />
-                          <strong>Type parameters:</strong> '?7892, '?7893, '?7894          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8257 * &#39;?8258 * &#39;?8259&gt;) -&gt; Series<br />
+                          <strong>Type parameters:</strong> '?8257, '?8258, '?8259                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L47-47" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -155,11 +156,11 @@
             New(data)
           </code>
           <div class="tip" id="1188">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?7889 * &#39;?7890&gt;) -&gt; Series<br />
-                          <strong>Type parameters:</strong> '?7889, '?7890          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?8254 * &#39;?8255&gt;) -&gt; Series<br />
+                          <strong>Type parameters:</strong> '?8254, '?8255                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L41-41" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L42-42" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -174,10 +175,10 @@
           </code>
           <div class="tip" id="1189">
             <strong>Signature:</strong> dps:seq&lt;Datum&gt; -&gt; Series<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L39-39" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -196,7 +197,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -259,6 +260,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-data.html
+++ b/docs/reference/xplot-googlecharts-data.html
@@ -5,7 +5,7 @@
     <title>Data - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Data</h1>
 <p>
   <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -74,13 +79,17 @@
           <td class="type-name">
             <a href="xplot-googlecharts-data-datum.html">Datum</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-googlecharts-data-series.html">Series</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -96,15 +105,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '49', 49)" onmouseover="showTip(event, '49', 49)">
+          <code onmouseout="hideTip(event, '7', 7)" onmouseover="showTip(event, '7', 7)">
             makeDataTable series labels
           </code>
-          <div class="tip" id="49">
+          <div class="tip" id="7">
             <strong>Signature:</strong> series:seq&lt;Series&gt; -&gt; labels:seq&lt;string&gt; option -&gt; DataTable<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L61-61" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L62-62" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -123,7 +132,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -186,6 +195,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-deedle.html
+++ b/docs/reference/xplot-googlecharts-deedle.html
@@ -5,7 +5,7 @@
     <title>Deedle - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Deedle</h1>
 <p>
   <span>Namespace: XPlot.GoogleCharts</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -73,15 +78,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '7', 7)" onmouseover="showTip(event, '7', 7)">
+          <code onmouseout="hideTip(event, '12', 12)" onmouseover="showTip(event, '12', 12)">
             Annotation(data, ?Options)
           </code>
-          <div class="tip" id="7">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+          <div class="tip" id="12">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L14-14" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L14-14" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,141 +99,141 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '8', 8)" onmouseover="showTip(event, '8', 8)">
-            Area(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="8">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7571&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7571          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L23-23" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates an area chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Area.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '9', 9)" onmouseover="showTip(event, '9', 9)">
-            Area(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="9">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7574&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7574          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L36-36" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates an area chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Area.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '10', 10)" onmouseover="showTip(event, '10', 10)">
-            Area(data, ?Options)
-          </code>
-          <div class="tip" id="10">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L50-50" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates an area chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Area.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '11', 11)" onmouseover="showTip(event, '11', 11)">
-            Bar(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="11">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7580&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7580          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L59-59" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a bar chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Bar.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '12', 12)" onmouseover="showTip(event, '12', 12)">
-            Bar(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="12">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7583&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7583          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L72-72" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a bar chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Bar.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
           <code onmouseout="hideTip(event, '13', 13)" onmouseover="showTip(event, '13', 13)">
-            Bar(data, ?Options)
+            Area(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="13">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9490                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L86-86" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L23-23" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a bar chart.</p>
+          <p>Creates an area chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Bar.Static</code></p>
+              <p>CompiledName: <code>Chart.Area.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '14', 14)" onmouseover="showTip(event, '14', 14)">
-            Bubble(data, ?Options)
+            Area(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="14">
-            <strong>Signature:</strong> (data:Frame&lt;string,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9493                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L94-94" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L36-36" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates an area chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Area.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '15', 15)" onmouseover="showTip(event, '15', 15)">
+            Area(data, ?Options)
+          </code>
+          <div class="tip" id="15">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L50-50" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates an area chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Area.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '16', 16)" onmouseover="showTip(event, '16', 16)">
+            Bar(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="16">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9499                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L59-59" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a bar chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Bar.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '17', 17)" onmouseover="showTip(event, '17', 17)">
+            Bar(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="17">
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9502                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L72-72" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a bar chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Bar.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '18', 18)" onmouseover="showTip(event, '18', 18)">
+            Bar(data, ?Options)
+          </code>
+          <div class="tip" id="18">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L86-86" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a bar chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Bar.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '19', 19)" onmouseover="showTip(event, '19', 19)">
+            Bubble(data, ?Options)
+          </code>
+          <div class="tip" id="19">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L94-94" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -241,15 +246,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '15', 15)" onmouseover="showTip(event, '15', 15)">
+          <code onmouseout="hideTip(event, '20', 20)" onmouseover="showTip(event, '20', 20)">
             Calendar(data, ?Labels, ?Options)
           </code>
-          <div class="tip" id="15">
-            <strong>Signature:</strong> (data:Series&lt;DateTime,&#39;?7590&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7590          </div>
+          <div class="tip" id="20">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9509                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L103-103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L103-103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -262,15 +267,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '16', 16)" onmouseover="showTip(event, '16', 16)">
+          <code onmouseout="hideTip(event, '21', 21)" onmouseover="showTip(event, '21', 21)">
             Calendar(data, ?Options)
           </code>
-          <div class="tip" id="16">
-            <strong>Signature:</strong> (data:Frame&lt;DateTime,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'V          </div>
+          <div class="tip" id="21">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L115-115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L115-115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -283,15 +288,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '17', 17)" onmouseover="showTip(event, '17', 17)">
+          <code onmouseout="hideTip(event, '22', 22)" onmouseover="showTip(event, '22', 22)">
             Candlestick(data, ?Options)
           </code>
-          <div class="tip" id="17">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+          <div class="tip" id="22">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L123-123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L123-123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -304,141 +309,120 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '18', 18)" onmouseover="showTip(event, '18', 18)">
-            Column(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="18">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7598&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7598          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L132-132" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a column chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Column.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '19', 19)" onmouseover="showTip(event, '19', 19)">
-            Column(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="19">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7601&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7601          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L145-145" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a column chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Column.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '20', 20)" onmouseover="showTip(event, '20', 20)">
-            Column(data, ?Options)
-          </code>
-          <div class="tip" id="20">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L159-159" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a column chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Column.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '21', 21)" onmouseover="showTip(event, '21', 21)">
-            Combo(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="21">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7607&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7607          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L168-168" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a combo chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Combo.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '22', 22)" onmouseover="showTip(event, '22', 22)">
-            Combo(data, ?Options)
-          </code>
-          <div class="tip" id="22">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L182-182" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a combo chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Combo.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
           <code onmouseout="hideTip(event, '23', 23)" onmouseover="showTip(event, '23', 23)">
-            Gauge(data, ?Labels, ?Options)
+            Column(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="23">
-            <strong>Signature:</strong> (data:Series&lt;string,&#39;?7612&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7612          </div>
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9517                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L191-191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L132-132" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a gauge chart.</p>
+          <p>Creates a column chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Gauge.Static</code></p>
+              <p>CompiledName: <code>Chart.Column.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '24', 24)" onmouseover="showTip(event, '24', 24)">
-            Gauge(data, ?Options)
+            Column(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="24">
-            <strong>Signature:</strong> (data:Frame&lt;string,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'V          </div>
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9520                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L203-203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L145-145" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a column chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Column.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '25', 25)" onmouseover="showTip(event, '25', 25)">
+            Column(data, ?Options)
+          </code>
+          <div class="tip" id="25">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L159-159" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a column chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Column.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '26', 26)" onmouseover="showTip(event, '26', 26)">
+            Combo(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="26">
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9526                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L168-168" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a combo chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Combo.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '27', 27)" onmouseover="showTip(event, '27', 27)">
+            Combo(data, ?Options)
+          </code>
+          <div class="tip" id="27">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L182-182" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a combo chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Combo.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '28', 28)" onmouseover="showTip(event, '28', 28)">
+            Gauge(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="28">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9531                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -451,162 +435,141 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '25', 25)" onmouseover="showTip(event, '25', 25)">
-            Geo(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="25">
-            <strong>Signature:</strong> (data:Series&lt;string,&#39;?7616&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7616          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L212-212" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a geo chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Geo.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '26', 26)" onmouseover="showTip(event, '26', 26)">
-            Geo(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="26">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;string,&#39;?7618&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7618          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L225-225" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a geo chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Geo.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '27', 27)" onmouseover="showTip(event, '27', 27)">
-            Geo(data, ?Options)
-          </code>
-          <div class="tip" id="27">
-            <strong>Signature:</strong> (data:Frame&lt;string,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L239-239" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a geo chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Geo.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '28', 28)" onmouseover="showTip(event, '28', 28)">
-            Histogram(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="28">
-            <strong>Signature:</strong> (data:Series&lt;string,&#39;?7622&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7622          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L248-248" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a histogram chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Histogram.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
           <code onmouseout="hideTip(event, '29', 29)" onmouseover="showTip(event, '29', 29)">
-            Histogram(data, ?Options)
+            Gauge(data, ?Options)
           </code>
           <div class="tip" id="29">
-            <strong>Signature:</strong> (data:Frame&lt;string,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L260-260" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L203-203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a histogram chart.</p>
+          <p>Creates a gauge chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Histogram.Static</code></p>
+              <p>CompiledName: <code>Chart.Gauge.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '30', 30)" onmouseover="showTip(event, '30', 30)">
-            Line(data, ?Labels, ?Options)
+            Geo(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="30">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7627&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7627          </div>
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9535                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L269-269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a line chart.</p>
+          <p>Creates a geo chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Line.Static</code></p>
+              <p>CompiledName: <code>Chart.Geo.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '31', 31)" onmouseover="showTip(event, '31', 31)">
-            Line(data, ?Labels, ?Options)
+            Geo(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="31">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7630&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7630          </div>
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9537                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L282-282" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L225-225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a line chart.</p>
+          <p>Creates a geo chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Line.Static</code></p>
+              <p>CompiledName: <code>Chart.Geo.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '32', 32)" onmouseover="showTip(event, '32', 32)">
-            Line(data, ?Options)
+            Geo(data, ?Options)
           </code>
           <div class="tip" id="32">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L296-296" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L239-239" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a geo chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Geo.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '33', 33)" onmouseover="showTip(event, '33', 33)">
+            Histogram(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="33">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9541                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L248-248" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a histogram chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Histogram.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '34', 34)" onmouseover="showTip(event, '34', 34)">
+            Histogram(data, ?Options)
+          </code>
+          <div class="tip" id="34">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L260-260" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a histogram chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Histogram.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '35', 35)" onmouseover="showTip(event, '35', 35)">
+            Line(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="35">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9546                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L269-269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -619,99 +582,141 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '33', 33)" onmouseover="showTip(event, '33', 33)">
-            Map(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="33">
-            <strong>Signature:</strong> (data:Series&lt;string,string&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                      </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L305-305" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a map chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Map.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '34', 34)" onmouseover="showTip(event, '34', 34)">
-            Map(data, ?Options)
-          </code>
-          <div class="tip" id="34">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L317-317" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a map chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Map.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '35', 35)" onmouseover="showTip(event, '35', 35)">
-            Pie(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="35">
-            <strong>Signature:</strong> (data:Series&lt;string,&#39;?7639&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7639          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L326-326" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a pie chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Pie.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
           <code onmouseout="hideTip(event, '36', 36)" onmouseover="showTip(event, '36', 36)">
-            Pie(data, ?Options)
+            Line(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="36">
-            <strong>Signature:</strong> (data:Frame&lt;string,&#39;?7641&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> '?7641          </div>
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9549                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L338-338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L282-282" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a pie chart.</p>
+          <p>Creates a line chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Pie.Static</code></p>
+              <p>CompiledName: <code>Chart.Line.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '37', 37)" onmouseover="showTip(event, '37', 37)">
-            Sankey(data, ?Options)
+            Line(data, ?Options)
           </code>
           <div class="tip" id="37">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L346-346" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L296-296" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a line chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Line.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '38', 38)" onmouseover="showTip(event, '38', 38)">
+            Map(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="38">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                                  </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L305-305" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a map chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Map.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '39', 39)" onmouseover="showTip(event, '39', 39)">
+            Map(data, ?Options)
+          </code>
+          <div class="tip" id="39">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L317-317" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a map chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Map.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '40', 40)" onmouseover="showTip(event, '40', 40)">
+            Pie(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="40">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9558                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L326-326" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a pie chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Pie.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '41', 41)" onmouseover="showTip(event, '41', 41)">
+            Pie(data, ?Options)
+          </code>
+          <div class="tip" id="41">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> '?9560                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L338-338" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a pie chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Pie.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '42', 42)" onmouseover="showTip(event, '42', 42)">
+            Sankey(data, ?Options)
+          </code>
+          <div class="tip" id="42">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L346-346" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -724,183 +729,141 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '38', 38)" onmouseover="showTip(event, '38', 38)">
-            Scatter(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="38">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7647&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7647          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L355-355" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a scatter chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '39', 39)" onmouseover="showTip(event, '39', 39)">
-            Scatter(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="39">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7650&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7650          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L368-368" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a scatter chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '40', 40)" onmouseover="showTip(event, '40', 40)">
-            Scatter(data, ?Options)
-          </code>
-          <div class="tip" id="40">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L382-382" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a scatter chart.</p>
-
-
-              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '41', 41)" onmouseover="showTip(event, '41', 41)">
-            SteppedArea(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="41">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7656&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7656          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L391-391" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a stepped area chart.</p>
-
-
-              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
-          <code onmouseout="hideTip(event, '42', 42)" onmouseover="showTip(event, '42', 42)">
-            SteppedArea(data, ?Labels, ?Options)
-          </code>
-          <div class="tip" id="42">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7659&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7659          </div>
-        </td>
-        <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L404-404" class="github-link">
-              <img src="../content/img/github.png" class="normal" />
-              <img src="../content/img/github-blue.png" class="hover" />
-            </a>
-          <p>Creates a stepped area chart.</p>
-
-
-              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="member-name">
-
           <code onmouseout="hideTip(event, '43', 43)" onmouseover="showTip(event, '43', 43)">
-            SteppedArea(data, ?Options)
+            Scatter(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="43">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9566                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L418-418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L355-355" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a stepped area chart.</p>
+          <p>Creates a scatter chart.</p>
 
 
-              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
+              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '44', 44)" onmouseover="showTip(event, '44', 44)">
-            Table(data, ?Labels, ?Options)
+            Scatter(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="44">
-            <strong>Signature:</strong> (data:Series&lt;&#39;K,&#39;?7665&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7665          </div>
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9569                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L427-427" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L368-368" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a table chart.</p>
+          <p>Creates a scatter chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Table.Static</code></p>
+              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '45', 45)" onmouseover="showTip(event, '45', 45)">
-            Table(data, ?Labels, ?Options)
+            Scatter(data, ?Options)
           </code>
           <div class="tip" id="45">
-            <strong>Signature:</strong> (data:seq&lt;Series&lt;&#39;K,&#39;?7668&gt;&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, '?7668          </div>
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L440-440" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L382-382" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
-          <p>Creates a table chart.</p>
+          <p>Creates a scatter chart.</p>
 
 
-              <p>CompiledName: <code>Chart.Table.Static</code></p>
+              <p>CompiledName: <code>Chart.Scatter.Static</code></p>
         </td>
       </tr>
       <tr>
         <td class="member-name">
 
           <code onmouseout="hideTip(event, '46', 46)" onmouseover="showTip(event, '46', 46)">
-            Table(data, ?Options)
+            SteppedArea(data, ?Labels, ?Options)
           </code>
           <div class="tip" id="46">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9575                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L454-454" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L391-391" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a stepped area chart.</p>
+
+
+              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '47', 47)" onmouseover="showTip(event, '47', 47)">
+            SteppedArea(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="47">
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9578                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L404-404" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a stepped area chart.</p>
+
+
+              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '48', 48)" onmouseover="showTip(event, '48', 48)">
+            SteppedArea(data, ?Options)
+          </code>
+          <div class="tip" id="48">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L418-418" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a stepped area chart.</p>
+
+
+              <p>CompiledName: <code>Chart.SteppedArea.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '49', 49)" onmouseover="showTip(event, '49', 49)">
+            Table(data, ?Labels, ?Options)
+          </code>
+          <div class="tip" id="49">
+            <strong>Signature:</strong> (data:(type) * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9584                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L427-427" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -913,15 +876,57 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '47', 47)" onmouseover="showTip(event, '47', 47)">
-            Timeline(data, ?Options)
+          <code onmouseout="hideTip(event, '50', 50)" onmouseover="showTip(event, '50', 50)">
+            Table(data, ?Labels, ?Options)
           </code>
-          <div class="tip" id="47">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+          <div class="tip" id="50">
+            <strong>Signature:</strong> (data:seq&lt;(type)&gt; * Labels:seq&lt;string&gt; option * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, '?9587                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L462-462" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L440-440" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a table chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Table.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '51', 51)" onmouseover="showTip(event, '51', 51)">
+            Table(data, ?Options)
+          </code>
+          <div class="tip" id="51">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L454-454" class="github-link">
+              <img src="../content/img/github.png" class="normal" />
+              <img src="../content/img/github-blue.png" class="hover" />
+            </a>
+          <p>Creates a table chart.</p>
+
+
+              <p>CompiledName: <code>Chart.Table.Static</code></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="member-name">
+
+          <code onmouseout="hideTip(event, '52', 52)" onmouseover="showTip(event, '52', 52)">
+            Timeline(data, ?Options)
+          </code>
+          <div class="tip" id="52">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
+        </td>
+        <td class="xmldoc">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L462-462" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -934,15 +939,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '48', 48)" onmouseover="showTip(event, '48', 48)">
+          <code onmouseout="hideTip(event, '53', 53)" onmouseover="showTip(event, '53', 53)">
             Treemap(data, ?Options)
           </code>
-          <div class="tip" id="48">
-            <strong>Signature:</strong> (data:Frame&lt;&#39;K,&#39;V&gt; * Options:Options option) -&gt; GoogleChart<br />
-                          <strong>Type parameters:</strong> 'K, 'V          </div>
+          <div class="tip" id="53">
+            <strong>Signature:</strong> (data:(type) * Options:Options option) -&gt; GoogleChart<br />
+                          <strong>Type parameters:</strong> 'K, 'V                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L470-470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts.Deedle/Deedle.fs#L470-470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -964,7 +969,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1027,6 +1032,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-googlechart.html
+++ b/docs/reference/xplot-googlecharts-googlechart.html
@@ -5,7 +5,7 @@
     <title>GoogleChart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>GoogleChart</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,14 @@
           <div class="tip" id="1266">
             <strong>Signature:</strong> DataTable<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L250-250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L251-251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -95,10 +100,14 @@
           <div class="tip" id="1267">
             <strong>Signature:</strong> Options<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L253-253" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L254-254" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,10 +123,14 @@
           <div class="tip" id="1268">
             <strong>Signature:</strong> ChartGallery<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L256-256" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L257-257" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -140,10 +153,10 @@
           </code>
           <div class="tip" id="1269">
             <strong>Signature:</strong> unit -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L247-247" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L248-248" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -167,10 +180,10 @@
           </code>
           <div class="tip" id="1270">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L333-333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L334-334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -188,10 +201,10 @@
           </code>
           <div class="tip" id="1271">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L333-333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L334-334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -209,10 +222,10 @@
           </code>
           <div class="tip" id="1272">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L274-274" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L275-275" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +242,10 @@
           </code>
           <div class="tip" id="1273">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L296-296" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L297-297" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +263,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1274">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L304-304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L305-305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -270,10 +283,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1275">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L325-325" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L326-326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +304,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1276">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L325-325" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L326-326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -312,10 +325,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1277">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L328-328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L329-329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -333,10 +346,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1278">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L328-328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L329-329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -354,10 +367,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1279">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L338-338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L339-339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -374,10 +387,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1280">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L347-347" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L348-348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -395,10 +408,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1281">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L347-347" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L348-348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -416,10 +429,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1282">
             <strong>Signature:</strong> newApiKey:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L356-356" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L357-357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -436,10 +449,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1283">
             <strong>Signature:</strong> height:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L350-350" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L351-351" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +469,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1284">
             <strong>Signature:</strong> newId:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L353-353" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L354-354" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -476,10 +489,10 @@ a reference to Google APIs and loads the required Google Charts packages).</p>
           </code>
           <div class="tip" id="1285">
             <strong>Signature:</strong> label:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L360-360" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L361-361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +510,10 @@ chart's data is a single series.</p>
           </code>
           <div class="tip" id="1286">
             <strong>Signature:</strong> labels:seq&lt;string&gt; -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L367-367" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L368-368" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -518,10 +531,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1287">
             <strong>Signature:</strong> enabled:bool -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L378-378" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L379-379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -538,10 +551,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1288">
             <strong>Signature:</strong> options:Options -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L390-390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L391-391" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -558,10 +571,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1289">
             <strong>Signature:</strong> (width:int * height:int) -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L401-401" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L402-402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +591,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1290">
             <strong>Signature:</strong> title:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L406-406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L407-407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -598,10 +611,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1291">
             <strong>Signature:</strong> width:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L410-410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L411-411" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -618,10 +631,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1292">
             <strong>Signature:</strong> xTitle:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L413-413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L414-414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -638,10 +651,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1293">
             <strong>Signature:</strong> yTitle:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L420-420" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L421-421" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -666,10 +679,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1294">
             <strong>Signature:</strong> data:seq&lt;Series&gt; -&gt; (labels:seq&lt;string&gt; option) -&gt; options:Options -&gt; type:ChartGallery -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L258-258" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L259-259" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -684,10 +697,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="1295">
             <strong>Signature:</strong> dataTable:DataTable -&gt; options:Options -&gt; type:ChartGallery -&gt; GoogleChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L266-266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L267-267" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -706,7 +719,7 @@ chart's data is a series collection.</p>
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -769,6 +782,6 @@ chart's data is a series collection.</p>
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-html.html
+++ b/docs/reference/xplot-googlecharts-html.html
@@ -5,7 +5,7 @@
     <title>Html - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,7 +58,7 @@
 <h1>Html</h1>
 <p>
   <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+  </p>
 <div class="xmldoc">
 </div>
 
@@ -73,15 +73,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '50', 50)" onmouseover="showTip(event, '50', 50)">
+          <code onmouseout="hideTip(event, '8', 8)" onmouseover="showTip(event, '8', 8)">
             formatDatasetTemplate 
           </code>
-          <div class="tip" id="50">
+          <div class="tip" id="8">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L162-162" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L163-163" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -91,15 +91,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '51', 51)" onmouseover="showTip(event, '51', 51)">
+          <code onmouseout="hideTip(event, '9', 9)" onmouseover="showTip(event, '9', 9)">
             inlineTemplate 
           </code>
-          <div class="tip" id="51">
+          <div class="tip" id="9">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L184-184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L185-185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -109,15 +109,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '52', 52)" onmouseover="showTip(event, '52', 52)">
+          <code onmouseout="hideTip(event, '10', 10)" onmouseover="showTip(event, '10', 10)">
             jsTemplate 
           </code>
-          <div class="tip" id="52">
+          <div class="tip" id="10">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L168-168" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -127,15 +127,15 @@
       <tr>
         <td class="member-name">
 
-          <code onmouseout="hideTip(event, '53', 53)" onmouseover="showTip(event, '53', 53)">
+          <code onmouseout="hideTip(event, '11', 11)" onmouseover="showTip(event, '11', 11)">
             pageTemplate 
           </code>
-          <div class="tip" id="53">
+          <div class="tip" id="11">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L190-190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.GoogleCharts/Main.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -154,7 +154,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -217,6 +217,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-key.html
+++ b/docs/reference/xplot-googlecharts-key.html
@@ -5,7 +5,7 @@
     <title>key - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>key</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+    </p>
 <div class="xmldoc">
 </div>
 
@@ -71,7 +72,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -134,6 +135,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-googlecharts-value.html
+++ b/docs/reference/xplot-googlecharts-value.html
@@ -5,7 +5,7 @@
     <title>value - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>value</h1>
 <p>
-  <span>Namespace: XPlot.GoogleCharts</span><br />
-</p>
+
+    <span>Namespace: XPlot.GoogleCharts</span><br />
+    </p>
 <div class="xmldoc">
 </div>
 
@@ -71,7 +72,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -134,6 +135,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-chart.html
+++ b/docs/reference/xplot-plotly-chart.html
@@ -5,7 +5,7 @@
     <title>Chart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Chart</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Static members</h3>
@@ -74,11 +75,11 @@
             Area(data)
           </code>
           <div class="tip" id="4576">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9173&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9173, '?9174, '?9175          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9664&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9664, '?9665, '?9666                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L319-319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L319-319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -92,11 +93,11 @@
             Area(data)
           </code>
           <div class="tip" id="4577">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9170 * &#39;?9171&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9170, '?9171          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9661 * &#39;?9662&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9661, '?9662                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L313-313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L313-313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -110,11 +111,11 @@
             Area(data)
           </code>
           <div class="tip" id="4578">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9168&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9168          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9659&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9659                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L308-308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L308-308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -128,11 +129,11 @@
             Bar(data)
           </code>
           <div class="tip" id="4579">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9182&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9182, '?9183, '?9184          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9673&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9673, '?9674, '?9675                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L341-341" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L341-341" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -146,11 +147,11 @@
             Bar(data)
           </code>
           <div class="tip" id="4580">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9179 * &#39;?9180&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9179, '?9180          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9670 * &#39;?9671&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9670, '?9671                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L335-335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L335-335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,11 +165,11 @@
             Bar(data)
           </code>
           <div class="tip" id="4581">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9177&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9177          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9668&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9668                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L331-331" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L331-331" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -182,11 +183,11 @@
             Bubble(data)
           </code>
           <div class="tip" id="4582">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9186 * &#39;?9187 * &#39;?9188&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9186, '?9187, '?9188          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9677 * &#39;?9678 * &#39;?9679&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9677, '?9678, '?9679                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L351-351" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L351-351" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -200,11 +201,11 @@
             Candlestick(data)
           </code>
           <div class="tip" id="4583">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9190 * &#39;?9191 * &#39;?9192 * &#39;?9193 * &#39;?9194&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9190, '?9191, '?9192, '?9193, '?9194          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9681 * &#39;?9682 * &#39;?9683 * &#39;?9684 * &#39;?9685&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9681, '?9682, '?9683, '?9684, '?9685                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L367-367" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L367-367" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -218,11 +219,11 @@
             Column(data)
           </code>
           <div class="tip" id="4584">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9201&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9201, '?9202, '?9203          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9692&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9692, '?9693, '?9694                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L389-389" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L389-389" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,11 +237,11 @@
             Column(data)
           </code>
           <div class="tip" id="4585">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9198 * &#39;?9199&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9198, '?9199          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9689 * &#39;?9690&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9689, '?9690                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L383-383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L383-383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -254,11 +255,11 @@
             Column(data)
           </code>
           <div class="tip" id="4586">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9196&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9196          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9687&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9687                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L379-379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L379-379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -272,11 +273,11 @@
             Line(data)
           </code>
           <div class="tip" id="4587">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9210&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9210, '?9211, '?9212          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9701&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9701, '?9702, '?9703                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L409-409" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L409-409" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -290,11 +291,11 @@
             Line(data)
           </code>
           <div class="tip" id="4588">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9207 * &#39;?9208&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9207, '?9208          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9698 * &#39;?9699&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9698, '?9699                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L403-403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L403-403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -308,11 +309,11 @@
             Line(data)
           </code>
           <div class="tip" id="4589">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9205&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9205          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9696&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9696                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L399-399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L399-399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,11 +327,11 @@
             Pie(data)
           </code>
           <div class="tip" id="4590">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9214 * &#39;?9215&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9214, '?9215          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9705 * &#39;?9706&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9705, '?9706                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L419-419" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L419-419" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -344,11 +345,11 @@
             Plot(data, layout)
           </code>
           <div class="tip" id="4591">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9152&gt; * layout:Layout) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9152          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9643&gt; * layout:Layout) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9643                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L230-230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L230-230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -363,10 +364,10 @@
           </code>
           <div class="tip" id="4592">
             <strong>Signature:</strong> (data:Trace * layout:Layout) -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L225-225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L225-225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -380,11 +381,11 @@
             Plot(data)
           </code>
           <div class="tip" id="4593">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9149&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9149          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9640&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9640                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -399,10 +400,10 @@
           </code>
           <div class="tip" id="4594">
             <strong>Signature:</strong> data:Trace -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L215-215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L215-215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -416,11 +417,11 @@
             Scatter(data)
           </code>
           <div class="tip" id="4595">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9222&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9222, '?9223, '?9224          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9713&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9713, '?9714, '?9715                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L435-435" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L435-435" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -434,11 +435,11 @@
             Scatter(data)
           </code>
           <div class="tip" id="4596">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9219 * &#39;?9220&gt;) -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9219, '?9220          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9710 * &#39;?9711&gt;) -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9710, '?9711                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L429-429" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L429-429" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,11 +453,11 @@
             Scatter(data)
           </code>
           <div class="tip" id="4597">
-            <strong>Signature:</strong> data:seq&lt;&#39;?9217&gt; -&gt; PlotlyChart<br />
-                          <strong>Type parameters:</strong> '?9217          </div>
+            <strong>Signature:</strong> data:seq&lt;&#39;?9708&gt; -&gt; PlotlyChart<br />
+                          <strong>Type parameters:</strong> '?9708                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L425-425" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L425-425" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -471,10 +472,10 @@
           </code>
           <div class="tip" id="4598">
             <strong>Signature:</strong> chart:PlotlyChart -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L236-236" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L236-236" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -491,10 +492,10 @@
           </code>
           <div class="tip" id="4599">
             <strong>Signature:</strong> charts:seq&lt;PlotlyChart&gt; -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L239-239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L239-239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +512,10 @@
           </code>
           <div class="tip" id="4600">
             <strong>Signature:</strong> height:int -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L246-246" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L246-246" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -531,10 +532,10 @@
           </code>
           <div class="tip" id="4601">
             <strong>Signature:</strong> id:string -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L251-251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L251-251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +552,10 @@
           </code>
           <div class="tip" id="4602">
             <strong>Signature:</strong> label:string -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L257-257" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L257-257" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -572,10 +573,10 @@ chart's data is a single series.</p>
           </code>
           <div class="tip" id="4603">
             <strong>Signature:</strong> labels:seq&lt;string&gt; -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L263-263" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L263-263" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -593,10 +594,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4604">
             <strong>Signature:</strong> layout:Layout -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L267-267" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L267-267" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -611,10 +612,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4605">
             <strong>Signature:</strong> enabled:bool -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L272-272" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L272-272" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -631,10 +632,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4606">
             <strong>Signature:</strong> options:Layout -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L277-277" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L277-277" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -651,10 +652,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4607">
             <strong>Signature:</strong> (size:(int * int)) -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L282-282" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L282-282" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -671,10 +672,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4608">
             <strong>Signature:</strong> title:string -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L287-287" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L287-287" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -691,10 +692,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4609">
             <strong>Signature:</strong> width:int -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L292-292" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L292-292" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -711,10 +712,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4610">
             <strong>Signature:</strong> xTitle:string -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L297-297" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L297-297" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -731,10 +732,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4611">
             <strong>Signature:</strong> yTitle:string -&gt; chart:PlotlyChart -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L302-302" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L302-302" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -755,7 +756,7 @@ chart's data is a series collection.</p>
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -818,6 +819,6 @@ chart's data is a series collection.</p>
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-angularaxis.html
+++ b/docs/reference/xplot-plotly-graph-angularaxis.html
@@ -5,7 +5,7 @@
     <title>Angularaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Angularaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1296">
             <strong>Signature:</strong> unit -&gt; Angularaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7715-7715" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7715-7715" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1297">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7735-7735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7735-7735" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1298">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7735-7735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7735-7735" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1299">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7769-7769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7769-7769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="1300">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7769-7769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7769-7769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="1301">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7730-7730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7730-7730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="1302">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7730-7730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7730-7730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="1303">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7783-7783" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7783-7783" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -243,10 +244,10 @@
           </code>
           <div class="tip" id="1304">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7790-7790" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7790-7790" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -261,10 +262,10 @@
           </code>
           <div class="tip" id="1305">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7782-7782" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7782-7782" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,10 +280,10 @@
           </code>
           <div class="tip" id="1306">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7784-7784" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7784-7784" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="1307">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7785-7785" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7785-7785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -315,10 +316,10 @@
           </code>
           <div class="tip" id="1308">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7788-7788" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7788-7788" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -333,10 +334,10 @@
           </code>
           <div class="tip" id="1309">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7787-7787" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7787-7787" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="1310">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7786-7786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7786-7786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="1311">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7789-7789" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7789-7789" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,10 +388,10 @@
           </code>
           <div class="tip" id="1312">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7791-7791" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7791-7791" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -405,10 +406,10 @@
           </code>
           <div class="tip" id="1313">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7740-7740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7740-7740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -426,10 +427,10 @@
           </code>
           <div class="tip" id="1314">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7740-7740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7740-7740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -447,10 +448,10 @@
           </code>
           <div class="tip" id="1315">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7745-7745" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7745-7745" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -468,10 +469,10 @@
           </code>
           <div class="tip" id="1316">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7745-7745" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7745-7745" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -489,10 +490,10 @@
           </code>
           <div class="tip" id="1317">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7760-7760" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7760-7760" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -510,10 +511,10 @@
           </code>
           <div class="tip" id="1318">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7760-7760" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7760-7760" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -531,10 +532,10 @@
           </code>
           <div class="tip" id="1319">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7755-7755" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7755-7755" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -552,10 +553,10 @@
           </code>
           <div class="tip" id="1320">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7755-7755" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7755-7755" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -573,10 +574,10 @@
           </code>
           <div class="tip" id="1321">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7750-7750" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7750-7750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -594,10 +595,10 @@
           </code>
           <div class="tip" id="1322">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7750-7750" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7750-7750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -615,10 +616,10 @@
           </code>
           <div class="tip" id="1323">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7765-7765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7765-7765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -636,10 +637,10 @@
           </code>
           <div class="tip" id="1324">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7765-7765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7765-7765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -657,10 +658,10 @@
           </code>
           <div class="tip" id="1325">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7774-7774" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7774-7774" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -678,10 +679,10 @@
           </code>
           <div class="tip" id="1326">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7774-7774" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7774-7774" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -703,7 +704,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -766,6 +767,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-annotation.html
+++ b/docs/reference/xplot-plotly-graph-annotation.html
@@ -5,7 +5,7 @@
     <title>Annotation - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Annotation</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1327">
             <strong>Signature:</strong> unit -&gt; Annotation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7326-7326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7326-7326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1328">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7372-7372" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7372-7372" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1329">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7372-7372" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7372-7372" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1330">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7402-7402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7402-7402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1331">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7402-7402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7402-7402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1332">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7407-7407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7407-7407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="1333">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7407-7407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7407-7407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="1334">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7412-7412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7412-7412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="1335">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7412-7412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7412-7412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="1336">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7417-7417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7417-7417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="1337">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7417-7417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7417-7417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="1338">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7422-7422" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7422-7422" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="1339">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7422-7422" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7422-7422" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="1340">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7427-7427" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7427-7427" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -376,10 +377,10 @@
           </code>
           <div class="tip" id="1341">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7427-7427" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7427-7427" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -397,10 +398,10 @@
           </code>
           <div class="tip" id="1342">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7377-7377" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7377-7377" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -418,10 +419,10 @@
           </code>
           <div class="tip" id="1343">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7377-7377" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7377-7377" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="1344">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7382-7382" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7382-7382" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -460,10 +461,10 @@
           </code>
           <div class="tip" id="1345">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7382-7382" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7382-7382" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="1346">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7387-7387" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7387-7387" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="1347">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7387-7387" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7387-7387" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -523,10 +524,10 @@
           </code>
           <div class="tip" id="1348">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7392-7392" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7392-7392" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -544,10 +545,10 @@
           </code>
           <div class="tip" id="1349">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7392-7392" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7392-7392" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -565,10 +566,10 @@
           </code>
           <div class="tip" id="1350">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7362-7362" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7362-7362" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -584,10 +585,10 @@
           </code>
           <div class="tip" id="1351">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7362-7362" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7362-7362" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -603,10 +604,10 @@
           </code>
           <div class="tip" id="1352">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7367-7367" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7367-7367" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -624,10 +625,10 @@
           </code>
           <div class="tip" id="1353">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7367-7367" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7367-7367" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -645,10 +646,10 @@
           </code>
           <div class="tip" id="1354">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7469-7469" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7469-7469" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -663,10 +664,10 @@
           </code>
           <div class="tip" id="1355">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7475-7475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7475-7475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -681,10 +682,10 @@
           </code>
           <div class="tip" id="1356">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7476-7476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7476-7476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -699,10 +700,10 @@
           </code>
           <div class="tip" id="1357">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7477-7477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7477-7477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="1358">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7478-7478" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7478-7478" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="1359">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7479-7479" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7479-7479" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -753,10 +754,10 @@
           </code>
           <div class="tip" id="1360">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7480-7480" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7480-7480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -771,10 +772,10 @@
           </code>
           <div class="tip" id="1361">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7470-7470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7470-7470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -789,10 +790,10 @@
           </code>
           <div class="tip" id="1362">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7471-7471" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7471-7471" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -807,10 +808,10 @@
           </code>
           <div class="tip" id="1363">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7472-7472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7472-7472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="1364">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7473-7473" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7473-7473" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="1365">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7467-7467" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7467-7467" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="1366">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7468-7468" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7468-7468" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="1367">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7474-7474" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7474-7474" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -897,10 +898,10 @@
           </code>
           <div class="tip" id="1368">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7465-7465" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7465-7465" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -915,10 +916,10 @@
           </code>
           <div class="tip" id="1369">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7466-7466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7466-7466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="1370">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7482-7482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7482-7482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -951,10 +952,10 @@
           </code>
           <div class="tip" id="1371">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7483-7483" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7483-7483" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="1372">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7481-7481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7481-7481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -987,10 +988,10 @@
           </code>
           <div class="tip" id="1373">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7485-7485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7485-7485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="1374">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7486-7486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7486-7486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1023,10 +1024,10 @@
           </code>
           <div class="tip" id="1375">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7484-7484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7484-7484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1041,10 +1042,10 @@
           </code>
           <div class="tip" id="1376">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7397-7397" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7397-7397" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1062,10 +1063,10 @@
           </code>
           <div class="tip" id="1377">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7397-7397" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7397-7397" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1083,10 +1084,10 @@
           </code>
           <div class="tip" id="1378">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7353-7353" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7353-7353" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1104,10 +1105,10 @@
           </code>
           <div class="tip" id="1379">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7353-7353" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7353-7353" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="1380">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7358-7358" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7358-7358" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1146,10 +1147,10 @@
           </code>
           <div class="tip" id="1381">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7358-7358" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7358-7358" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1167,10 +1168,10 @@
           </code>
           <div class="tip" id="1382">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7437-7437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7437-7437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1188,10 +1189,10 @@
           </code>
           <div class="tip" id="1383">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7437-7437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7437-7437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1209,10 +1210,10 @@
           </code>
           <div class="tip" id="1384">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7442-7442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7442-7442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1230,10 +1231,10 @@
           </code>
           <div class="tip" id="1385">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7442-7442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7442-7442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1251,10 +1252,10 @@
           </code>
           <div class="tip" id="1386">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7432-7432" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7432-7432" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1272,10 +1273,10 @@
           </code>
           <div class="tip" id="1387">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7432-7432" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7432-7432" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="1388">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7452-7452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7452-7452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1314,10 +1315,10 @@
           </code>
           <div class="tip" id="1389">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7452-7452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7452-7452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1335,10 +1336,10 @@
           </code>
           <div class="tip" id="1390">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7457-7457" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7457-7457" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1356,10 +1357,10 @@
           </code>
           <div class="tip" id="1391">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7457-7457" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7457-7457" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="1392">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7447-7447" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7447-7447" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1398,10 +1399,10 @@
           </code>
           <div class="tip" id="1393">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7447-7447" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7447-7447" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1423,7 +1424,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1486,6 +1487,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-annotations.html
+++ b/docs/reference/xplot-plotly-graph-annotations.html
@@ -5,7 +5,7 @@
     <title>Annotations - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Annotations</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1394">
             <strong>Signature:</strong> unit -&gt; Annotations<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7591-7591" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7591-7591" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1395">
             <strong>Signature:</strong> unit -&gt; Items<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7596-7596" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7596-7596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1396">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7596-7596" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7596-7596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1397">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7604-7604" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7604-7604" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,7 +164,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -226,6 +227,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-area.html
+++ b/docs/reference/xplot-plotly-graph-area.html
@@ -5,7 +5,7 @@
     <title>Area - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Area</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1398">
             <strong>Signature:</strong> unit -&gt; Area<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5428-5428" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5428-5428" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1399">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5480-5480" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5480-5480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1400">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5480-5480" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5480-5480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1401">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5461-5461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5461-5461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1402">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5461-5461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5461-5461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1403">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5498-5498" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5498-5498" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -206,10 +207,10 @@
           </code>
           <div class="tip" id="1404">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5498-5498" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5498-5498" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="1405">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5466-5466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5466-5466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="1406">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5466-5466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5466-5466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="1407">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5489-5489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5489-5489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="1408">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5489-5489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5489-5489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="1409">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5503-5503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5503-5503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="1410">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5503-5503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5503-5503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="1411">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5519-5519" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5519-5519" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -369,10 +370,10 @@
           </code>
           <div class="tip" id="1412">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5515-5515" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5515-5515" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,10 +388,10 @@
           </code>
           <div class="tip" id="1413">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5523-5523" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5523-5523" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -405,10 +406,10 @@
           </code>
           <div class="tip" id="1414">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5516-5516" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5516-5516" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -423,10 +424,10 @@
           </code>
           <div class="tip" id="1415">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5521-5521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5521-5521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -441,10 +442,10 @@
           </code>
           <div class="tip" id="1416">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5524-5524" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5524-5524" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -459,10 +460,10 @@
           </code>
           <div class="tip" id="1417">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5514-5514" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5514-5514" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="1418">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5520-5520" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5520-5520" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -495,10 +496,10 @@
           </code>
           <div class="tip" id="1419">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5522-5522" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5522-5522" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -513,10 +514,10 @@
           </code>
           <div class="tip" id="1420">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5525-5525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5525-5525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -531,10 +532,10 @@
           </code>
           <div class="tip" id="1421">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5512-5512" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5512-5512" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -549,10 +550,10 @@
           </code>
           <div class="tip" id="1422">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5518-5518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5518-5518" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -567,10 +568,10 @@
           </code>
           <div class="tip" id="1423">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5513-5513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5513-5513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -585,10 +586,10 @@
           </code>
           <div class="tip" id="1424">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5456-5456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5456-5456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -606,10 +607,10 @@
           </code>
           <div class="tip" id="1425">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5456-5456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5456-5456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -627,10 +628,10 @@
           </code>
           <div class="tip" id="1426">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5484-5484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5484-5484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -646,10 +647,10 @@
           </code>
           <div class="tip" id="1427">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5484-5484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5484-5484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -665,10 +666,10 @@
           </code>
           <div class="tip" id="1428">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5494-5494" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5494-5494" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -686,10 +687,10 @@
           </code>
           <div class="tip" id="1429">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5494-5494" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5494-5494" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -707,10 +708,10 @@
           </code>
           <div class="tip" id="1430">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5508-5508" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5508-5508" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -728,10 +729,10 @@
           </code>
           <div class="tip" id="1431">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5508-5508" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5508-5508" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -749,10 +750,10 @@
           </code>
           <div class="tip" id="1432">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5446-5446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5446-5446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -768,10 +769,10 @@
           </code>
           <div class="tip" id="1433">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5446-5446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5446-5446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -787,10 +788,10 @@
           </code>
           <div class="tip" id="1434">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5475-5475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5475-5475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -808,10 +809,10 @@
           </code>
           <div class="tip" id="1435">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5475-5475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5475-5475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -829,10 +830,10 @@
           </code>
           <div class="tip" id="1436">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5451-5451" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5451-5451" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -850,10 +851,10 @@
           </code>
           <div class="tip" id="1437">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5451-5451" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5451-5451" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -875,7 +876,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -938,6 +939,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-aspectratio.html
+++ b/docs/reference/xplot-plotly-graph-aspectratio.html
@@ -5,7 +5,7 @@
     <title>Aspectratio - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Aspectratio</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1438">
             <strong>Signature:</strong> unit -&gt; Aspectratio<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6454-6454" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6454-6454" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1439">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6482-6482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6482-6482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="1440">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6483-6483" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6483-6483" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="1441">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6484-6484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6484-6484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="1442">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6462-6462" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6462-6462" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -176,10 +177,10 @@
           </code>
           <div class="tip" id="1443">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6462-6462" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6462-6462" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="1444">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6466-6466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6466-6466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="1445">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6466-6466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6466-6466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="1446">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6470-6470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6470-6470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="1447">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6470-6470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6470-6470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-bar.html
+++ b/docs/reference/xplot-plotly-graph-bar.html
@@ -5,7 +5,7 @@
     <title>Bar - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Bar</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1448">
             <strong>Signature:</strong> unit -&gt; Bar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2113-2113" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2113-2113" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1449">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2199-2199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2199-2199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1450">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2199-2199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2199-2199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1451">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2214-2214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2214-2214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1452">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2214-2214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2214-2214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1453">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2246-2246" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2246-2246" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -206,10 +207,10 @@
           </code>
           <div class="tip" id="1454">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2246-2246" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2246-2246" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="1455">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2242-2242" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2242-2242" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="1456">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2242-2242" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2242-2242" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="1457">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2180-2180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2180-2180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -284,10 +285,10 @@
           </code>
           <div class="tip" id="1458">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2180-2180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2180-2180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="1459">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2161-2161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2161-2161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="1460">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2161-2161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2161-2161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="1461">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2228-2228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2228-2228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -366,10 +367,10 @@
           </code>
           <div class="tip" id="1462">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2228-2228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2228-2228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -385,10 +386,10 @@
           </code>
           <div class="tip" id="1463">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2166-2166" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2166-2166" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -406,10 +407,10 @@
           </code>
           <div class="tip" id="1464">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2166-2166" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2166-2166" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -427,10 +428,10 @@
           </code>
           <div class="tip" id="1465">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2224-2224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2224-2224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -448,10 +449,10 @@
           </code>
           <div class="tip" id="1466">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2224-2224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2224-2224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -469,10 +470,10 @@
           </code>
           <div class="tip" id="1467">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2233-2233" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2233-2233" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -490,10 +491,10 @@
           </code>
           <div class="tip" id="1468">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2233-2233" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2233-2233" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +512,10 @@
           </code>
           <div class="tip" id="1469">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2276-2276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2276-2276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -532,10 +533,10 @@
           </code>
           <div class="tip" id="1470">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2276-2276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2276-2276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="1471">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2296-2296" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2296-2296" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -571,10 +572,10 @@
           </code>
           <div class="tip" id="1472">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2299-2299" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2299-2299" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -589,10 +590,10 @@
           </code>
           <div class="tip" id="1473">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2306-2306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2306-2306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -607,10 +608,10 @@
           </code>
           <div class="tip" id="1474">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2305-2305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2305-2305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -625,10 +626,10 @@
           </code>
           <div class="tip" id="1475">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2292-2292" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2292-2292" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -643,10 +644,10 @@
           </code>
           <div class="tip" id="1476">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2288-2288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2288-2288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -661,10 +662,10 @@
           </code>
           <div class="tip" id="1477">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2302-2302" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2302-2302" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,10 +680,10 @@
           </code>
           <div class="tip" id="1478">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2289-2289" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2289-2289" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -697,10 +698,10 @@
           </code>
           <div class="tip" id="1479">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2301-2301" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2301-2301" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -715,10 +716,10 @@
           </code>
           <div class="tip" id="1480">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2303-2303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2303-2303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -733,10 +734,10 @@
           </code>
           <div class="tip" id="1481">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2312-2312" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2312-2312" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -751,10 +752,10 @@
           </code>
           <div class="tip" id="1482">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2287-2287" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2287-2287" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -769,10 +770,10 @@
           </code>
           <div class="tip" id="1483">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2293-2293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2293-2293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -787,10 +788,10 @@
           </code>
           <div class="tip" id="1484">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2304-2304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2304-2304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -805,10 +806,10 @@
           </code>
           <div class="tip" id="1485">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2300-2300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2300-2300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -823,10 +824,10 @@
           </code>
           <div class="tip" id="1486">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2311-2311" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2311-2311" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -841,10 +842,10 @@
           </code>
           <div class="tip" id="1487">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2313-2313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2313-2313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -859,10 +860,10 @@
           </code>
           <div class="tip" id="1488">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2285-2285" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2285-2285" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -877,10 +878,10 @@
           </code>
           <div class="tip" id="1489">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2291-2291" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2291-2291" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -895,10 +896,10 @@
           </code>
           <div class="tip" id="1490">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2286-2286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2286-2286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -913,10 +914,10 @@
           </code>
           <div class="tip" id="1491">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2294-2294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2294-2294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -931,10 +932,10 @@
           </code>
           <div class="tip" id="1492">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2295-2295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2295-2295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -949,10 +950,10 @@
           </code>
           <div class="tip" id="1493">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2307-2307" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2307-2307" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -967,10 +968,10 @@
           </code>
           <div class="tip" id="1494">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2309-2309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2309-2309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -985,10 +986,10 @@
           </code>
           <div class="tip" id="1495">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2297-2297" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2297-2297" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1003,10 +1004,10 @@
           </code>
           <div class="tip" id="1496">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2298-2298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2298-2298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1021,10 +1022,10 @@
           </code>
           <div class="tip" id="1497">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2308-2308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2308-2308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1039,10 +1040,10 @@
           </code>
           <div class="tip" id="1498">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2310-2310" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2310-2310" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1057,10 +1058,10 @@
           </code>
           <div class="tip" id="1499">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2156-2156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2156-2156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1078,10 +1079,10 @@
           </code>
           <div class="tip" id="1500">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2156-2156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2156-2156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1099,10 +1100,10 @@
           </code>
           <div class="tip" id="1501">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2184-2184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2184-2184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1118,10 +1119,10 @@
           </code>
           <div class="tip" id="1502">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2184-2184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2184-2184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1137,10 +1138,10 @@
           </code>
           <div class="tip" id="1503">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2238-2238" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2238-2238" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1158,10 +1159,10 @@
           </code>
           <div class="tip" id="1504">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2238-2238" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2238-2238" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1179,10 +1180,10 @@
           </code>
           <div class="tip" id="1505">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2219-2219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2219-2219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1200,10 +1201,10 @@
           </code>
           <div class="tip" id="1506">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2219-2219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2219-2219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1221,10 +1222,10 @@
           </code>
           <div class="tip" id="1507">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2271-2271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2271-2271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1242,10 +1243,10 @@
           </code>
           <div class="tip" id="1508">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2271-2271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2271-2271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1263,10 +1264,10 @@
           </code>
           <div class="tip" id="1509">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2281-2281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2281-2281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1284,10 +1285,10 @@
           </code>
           <div class="tip" id="1510">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2281-2281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2281-2281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1305,10 +1306,10 @@
           </code>
           <div class="tip" id="1511">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2146-2146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2146-2146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1324,10 +1325,10 @@
           </code>
           <div class="tip" id="1512">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2146-2146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2146-2146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1343,10 +1344,10 @@
           </code>
           <div class="tip" id="1513">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2175-2175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2175-2175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1362,10 +1363,10 @@
           </code>
           <div class="tip" id="1514">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2175-2175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2175-2175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1381,10 +1382,10 @@
           </code>
           <div class="tip" id="1515">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2151-2151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2151-2151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1402,10 +1403,10 @@
           </code>
           <div class="tip" id="1516">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2151-2151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2151-2151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1423,10 +1424,10 @@
           </code>
           <div class="tip" id="1517">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2189-2189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2189-2189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1444,10 +1445,10 @@
           </code>
           <div class="tip" id="1518">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2189-2189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2189-2189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1465,10 +1466,10 @@
           </code>
           <div class="tip" id="1519">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2194-2194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2194-2194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1486,10 +1487,10 @@
           </code>
           <div class="tip" id="1520">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2194-2194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2194-2194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1507,10 +1508,10 @@
           </code>
           <div class="tip" id="1521">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2251-2251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2251-2251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1528,10 +1529,10 @@
           </code>
           <div class="tip" id="1522">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2251-2251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2251-2251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1549,10 +1550,10 @@
           </code>
           <div class="tip" id="1523">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2261-2261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2261-2261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1570,10 +1571,10 @@
           </code>
           <div class="tip" id="1524">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2261-2261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2261-2261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1591,10 +1592,10 @@
           </code>
           <div class="tip" id="1525">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2204-2204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2204-2204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1612,10 +1613,10 @@
           </code>
           <div class="tip" id="1526">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2204-2204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2204-2204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1633,10 +1634,10 @@
           </code>
           <div class="tip" id="1527">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2209-2209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2209-2209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1654,10 +1655,10 @@
           </code>
           <div class="tip" id="1528">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2209-2209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2209-2209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1675,10 +1676,10 @@
           </code>
           <div class="tip" id="1529">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2256-2256" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2256-2256" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1696,10 +1697,10 @@
           </code>
           <div class="tip" id="1530">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2256-2256" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2256-2256" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1717,10 +1718,10 @@
           </code>
           <div class="tip" id="1531">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2266-2266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2266-2266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1738,10 +1739,10 @@
           </code>
           <div class="tip" id="1532">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2266-2266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2266-2266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1763,7 +1764,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1826,6 +1827,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-box.html
+++ b/docs/reference/xplot-plotly-graph-box.html
@@ -5,7 +5,7 @@
     <title>Box - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Box</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1533">
             <strong>Signature:</strong> unit -&gt; Box<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2315-2315" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2315-2315" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1534">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2418-2418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2418-2418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1535">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2418-2418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2418-2418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1536">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2413-2413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2413-2413" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1537">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2413-2413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2413-2413" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1538">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2446-2446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2446-2446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="1539">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2446-2446" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2446-2446" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="1540">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2379-2379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2379-2379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="1541">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2379-2379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2379-2379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="1542">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2423-2423" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2423-2423" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="1543">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2423-2423" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2423-2423" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="1544">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2360-2360" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2360-2360" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="1545">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2360-2360" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2360-2360" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="1546">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2441-2441" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2441-2441" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -374,10 +375,10 @@
           </code>
           <div class="tip" id="1547">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2441-2441" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2441-2441" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="1548">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2437-2437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2437-2437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -412,10 +413,10 @@
           </code>
           <div class="tip" id="1549">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2437-2437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2437-2437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="1550">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2365-2365" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2365-2365" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="1551">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2365-2365" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2365-2365" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="1552">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2433-2433" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2433-2433" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="1553">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2433-2433" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2433-2433" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="1554">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2428-2428" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2428-2428" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="1555">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2428-2428" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2428-2428" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="1556">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2485-2485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2485-2485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -575,10 +576,10 @@
           </code>
           <div class="tip" id="1557">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2484-2484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2484-2484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -593,10 +594,10 @@
           </code>
           <div class="tip" id="1558">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2491-2491" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2491-2491" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -611,10 +612,10 @@
           </code>
           <div class="tip" id="1559">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2477-2477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2477-2477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -629,10 +630,10 @@
           </code>
           <div class="tip" id="1560">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2486-2486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2486-2486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -647,10 +648,10 @@
           </code>
           <div class="tip" id="1561">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2473-2473" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2473-2473" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -665,10 +666,10 @@
           </code>
           <div class="tip" id="1562">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2490-2490" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2490-2490" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="1563">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2489-2489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2489-2489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -701,10 +702,10 @@
           </code>
           <div class="tip" id="1564">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2474-2474" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2474-2474" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -719,10 +720,10 @@
           </code>
           <div class="tip" id="1565">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2488-2488" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2488-2488" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -737,10 +738,10 @@
           </code>
           <div class="tip" id="1566">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2487-2487" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2487-2487" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -755,10 +756,10 @@
           </code>
           <div class="tip" id="1567">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2472-2472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2472-2472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -773,10 +774,10 @@
           </code>
           <div class="tip" id="1568">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2478-2478" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2478-2478" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -791,10 +792,10 @@
           </code>
           <div class="tip" id="1569">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2470-2470" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2470-2470" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -809,10 +810,10 @@
           </code>
           <div class="tip" id="1570">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2476-2476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2476-2476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -827,10 +828,10 @@
           </code>
           <div class="tip" id="1571">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2471-2471" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2471-2471" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -845,10 +846,10 @@
           </code>
           <div class="tip" id="1572">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2483-2483" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2483-2483" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -863,10 +864,10 @@
           </code>
           <div class="tip" id="1573">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2480-2480" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2480-2480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -881,10 +882,10 @@
           </code>
           <div class="tip" id="1574">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2481-2481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2481-2481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -899,10 +900,10 @@
           </code>
           <div class="tip" id="1575">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2492-2492" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2492-2492" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -917,10 +918,10 @@
           </code>
           <div class="tip" id="1576">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2495-2495" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2495-2495" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -935,10 +936,10 @@
           </code>
           <div class="tip" id="1577">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2479-2479" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2479-2479" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -953,10 +954,10 @@
           </code>
           <div class="tip" id="1578">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2482-2482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2482-2482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -971,10 +972,10 @@
           </code>
           <div class="tip" id="1579">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2493-2493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2493-2493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -989,10 +990,10 @@
           </code>
           <div class="tip" id="1580">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2494-2494" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2494-2494" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,10 +1008,10 @@
           </code>
           <div class="tip" id="1581">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2355-2355" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2355-2355" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1028,10 +1029,10 @@
           </code>
           <div class="tip" id="1582">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2355-2355" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2355-2355" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1049,10 +1050,10 @@
           </code>
           <div class="tip" id="1583">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2383-2383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2383-2383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1068,10 +1069,10 @@
           </code>
           <div class="tip" id="1584">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2383-2383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2383-2383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1087,10 +1088,10 @@
           </code>
           <div class="tip" id="1585">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2345-2345" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2345-2345" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1106,10 +1107,10 @@
           </code>
           <div class="tip" id="1586">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2345-2345" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2345-2345" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="1587">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2374-2374" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2374-2374" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1146,10 +1147,10 @@
           </code>
           <div class="tip" id="1588">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2374-2374" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2374-2374" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1167,10 +1168,10 @@
           </code>
           <div class="tip" id="1589">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2350-2350" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2350-2350" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1188,10 +1189,10 @@
           </code>
           <div class="tip" id="1590">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2350-2350" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2350-2350" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1209,10 +1210,10 @@
           </code>
           <div class="tip" id="1591">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2408-2408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2408-2408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1230,10 +1231,10 @@
           </code>
           <div class="tip" id="1592">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2408-2408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2408-2408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1251,10 +1252,10 @@
           </code>
           <div class="tip" id="1593">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2393-2393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2393-2393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1272,10 +1273,10 @@
           </code>
           <div class="tip" id="1594">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2393-2393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2393-2393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="1595">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2398-2398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2398-2398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1314,10 +1315,10 @@
           </code>
           <div class="tip" id="1596">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2398-2398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2398-2398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1335,10 +1336,10 @@
           </code>
           <div class="tip" id="1597">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2451-2451" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2451-2451" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1356,10 +1357,10 @@
           </code>
           <div class="tip" id="1598">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2451-2451" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2451-2451" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="1599">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2466-2466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2466-2466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1398,10 +1399,10 @@
           </code>
           <div class="tip" id="1600">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2466-2466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2466-2466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1419,10 +1420,10 @@
           </code>
           <div class="tip" id="1601">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2388-2388" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2388-2388" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1440,10 +1441,10 @@
           </code>
           <div class="tip" id="1602">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2388-2388" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2388-2388" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1461,10 +1462,10 @@
           </code>
           <div class="tip" id="1603">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2403-2403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2403-2403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1482,10 +1483,10 @@
           </code>
           <div class="tip" id="1604">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2403-2403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2403-2403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1503,10 +1504,10 @@
           </code>
           <div class="tip" id="1605">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2456-2456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2456-2456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1524,10 +1525,10 @@
           </code>
           <div class="tip" id="1606">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2456-2456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2456-2456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1545,10 +1546,10 @@
           </code>
           <div class="tip" id="1607">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2461-2461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2461-2461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1566,10 +1567,10 @@
           </code>
           <div class="tip" id="1608">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2461-2461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2461-2461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1591,7 +1592,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1654,6 +1655,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-camera.html
+++ b/docs/reference/xplot-plotly-graph-camera.html
@@ -5,7 +5,7 @@
     <title>Camera - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Camera</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1609">
             <strong>Signature:</strong> unit -&gt; Camera<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6488-6488" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6488-6488" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1610">
             <strong>Signature:</strong> unit -&gt; Center<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6499-6499" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6499-6499" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="1611">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6499-6499" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6499-6499" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="1612">
             <strong>Signature:</strong> unit -&gt; Eye<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6503-6503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6503-6503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="1613">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6503-6503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6503-6503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="1614">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6512-6512" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6512-6512" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="1615">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6513-6513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6513-6513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -215,10 +216,10 @@
           </code>
           <div class="tip" id="1616">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6511-6511" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6511-6511" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="1617">
             <strong>Signature:</strong> unit -&gt; Up<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6495-6495" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6495-6495" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="1618">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6495-6495" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6495-6495" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-candlestick.html
+++ b/docs/reference/xplot-plotly-graph-candlestick.html
@@ -5,7 +5,7 @@
     <title>Candlestick - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Candlestick</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1619">
             <strong>Signature:</strong> unit -&gt; Candlestick<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1990-1990" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1990-1990" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1620">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2068-2068" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2068-2068" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1621">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2068-2068" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2068-2068" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1622">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2078-2078" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2078-2078" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1623">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2078-2078" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2078-2078" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1624">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2058-2058" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2058-2058" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="1625">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2058-2058" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2058-2058" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="1626">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2039-2039" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2039-2039" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="1627">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2039-2039" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2039-2039" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="1628">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2073-2073" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2073-2073" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="1629">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2073-2073" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2073-2073" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="1630">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2025-2025" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2025-2025" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="1631">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2025-2025" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2025-2025" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="1632">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2063-2063" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2063-2063" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -376,10 +377,10 @@
           </code>
           <div class="tip" id="1633">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2063-2063" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2063-2063" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -397,10 +398,10 @@
           </code>
           <div class="tip" id="1634">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2030-2030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2030-2030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -418,10 +419,10 @@
           </code>
           <div class="tip" id="1635">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2030-2030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2030-2030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="1636">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2053-2053" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2053-2053" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -460,10 +461,10 @@
           </code>
           <div class="tip" id="1637">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2053-2053" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2053-2053" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="1638">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2104-2104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2104-2104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,10 +500,10 @@
           </code>
           <div class="tip" id="1639">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2106-2106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2106-2106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -517,10 +518,10 @@
           </code>
           <div class="tip" id="1640">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2102-2102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2102-2102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -535,10 +536,10 @@
           </code>
           <div class="tip" id="1641">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2098-2098" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2098-2098" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="1642">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2105-2105" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2105-2105" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -571,10 +572,10 @@
           </code>
           <div class="tip" id="1643">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2095-2095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2095-2095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -589,10 +590,10 @@
           </code>
           <div class="tip" id="1644">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2103-2103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2103-2103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -607,10 +608,10 @@
           </code>
           <div class="tip" id="1645">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2096-2096" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2096-2096" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -625,10 +626,10 @@
           </code>
           <div class="tip" id="1646">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2101-2101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2101-2101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -643,10 +644,10 @@
           </code>
           <div class="tip" id="1647">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2094-2094" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2094-2094" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -661,10 +662,10 @@
           </code>
           <div class="tip" id="1648">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2099-2099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2099-2099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,10 +680,10 @@
           </code>
           <div class="tip" id="1649">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2092-2092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2092-2092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -697,10 +698,10 @@
           </code>
           <div class="tip" id="1650">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2097-2097" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2097-2097" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -715,10 +716,10 @@
           </code>
           <div class="tip" id="1651">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2093-2093" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2093-2093" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -733,10 +734,10 @@
           </code>
           <div class="tip" id="1652">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2100-2100" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2100-2100" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -751,10 +752,10 @@
           </code>
           <div class="tip" id="1653">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2107-2107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2107-2107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -769,10 +770,10 @@
           </code>
           <div class="tip" id="1654">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2108-2108" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2108-2108" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -787,10 +788,10 @@
           </code>
           <div class="tip" id="1655">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2020-2020" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2020-2020" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -808,10 +809,10 @@
           </code>
           <div class="tip" id="1656">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2020-2020" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2020-2020" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -829,10 +830,10 @@
           </code>
           <div class="tip" id="1657">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2043-2043" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2043-2043" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -848,10 +849,10 @@
           </code>
           <div class="tip" id="1658">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2043-2043" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2043-2043" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -867,10 +868,10 @@
           </code>
           <div class="tip" id="1659">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2010-2010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2010-2010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -886,10 +887,10 @@
           </code>
           <div class="tip" id="1660">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2010-2010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2010-2010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -905,10 +906,10 @@
           </code>
           <div class="tip" id="1661">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2034-2034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2034-2034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -924,10 +925,10 @@
           </code>
           <div class="tip" id="1662">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2034-2034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2034-2034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -943,10 +944,10 @@
           </code>
           <div class="tip" id="1663">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2015-2015" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2015-2015" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -964,10 +965,10 @@
           </code>
           <div class="tip" id="1664">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2015-2015" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2015-2015" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -985,10 +986,10 @@
           </code>
           <div class="tip" id="1665">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2048-2048" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2048-2048" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1006,10 +1007,10 @@
           </code>
           <div class="tip" id="1666">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2048-2048" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2048-2048" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1027,10 +1028,10 @@
           </code>
           <div class="tip" id="1667">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2083-2083" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2083-2083" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1048,10 +1049,10 @@
           </code>
           <div class="tip" id="1668">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2083-2083" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2083-2083" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1069,10 +1070,10 @@
           </code>
           <div class="tip" id="1669">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2088-2088" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2088-2088" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1090,10 +1091,10 @@
           </code>
           <div class="tip" id="1670">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2088-2088" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2088-2088" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1115,7 +1116,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1178,6 +1179,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-center.html
+++ b/docs/reference/xplot-plotly-graph-center.html
@@ -5,7 +5,7 @@
     <title>Center - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Center</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1671">
             <strong>Signature:</strong> unit -&gt; Center<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6386-6386" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6386-6386" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1672">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6414-6414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6414-6414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="1673">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6415-6415" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6415-6415" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="1674">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6416-6416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6416-6416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="1675">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6394-6394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6394-6394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -176,10 +177,10 @@
           </code>
           <div class="tip" id="1676">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6394-6394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6394-6394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="1677">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6398-6398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6398-6398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="1678">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6398-6398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6398-6398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="1679">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6402-6402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6402-6402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="1680">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6402-6402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6402-6402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-choropleth.html
+++ b/docs/reference/xplot-plotly-graph-choropleth.html
@@ -5,7 +5,7 @@
     <title>Choropleth - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Choropleth</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1681">
             <strong>Signature:</strong> unit -&gt; Choropleth<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5052-5052" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5052-5052" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1682">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5169-5169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5169-5169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1683">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5169-5169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5169-5169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1684">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5183-5183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5183-5183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="1685">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5183-5183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5183-5183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="1686">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5164-5164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5164-5164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="1687">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5164-5164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5164-5164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="1688">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5188-5188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5188-5188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="1689">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5188-5188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5188-5188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="1690">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5116-5116" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5116-5116" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="1691">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5116-5116" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5116-5116" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="1692">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5097-5097" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5097-5097" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="1693">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5097-5097" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5097-5097" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="1694">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5130-5130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5130-5130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="1695">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5130-5130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5130-5130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="1696">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5125-5125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5125-5125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,10 +415,10 @@
           </code>
           <div class="tip" id="1697">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5125-5125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5125-5125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="1698">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5193-5193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5193-5193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +457,10 @@
           </code>
           <div class="tip" id="1699">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5193-5193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5193-5193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="1700">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5144-5144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5144-5144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -496,10 +497,10 @@
           </code>
           <div class="tip" id="1701">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5144-5144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5144-5144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="1702">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5102-5102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5102-5102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="1703">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5102-5102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5102-5102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="1704">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5174-5174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5174-5174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="1705">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5174-5174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5174-5174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="1706">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5225-5225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5225-5225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -617,10 +618,10 @@
           </code>
           <div class="tip" id="1707">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5228-5228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5228-5228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -635,10 +636,10 @@
           </code>
           <div class="tip" id="1708">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5224-5224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5224-5224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -653,10 +654,10 @@
           </code>
           <div class="tip" id="1709">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5229-5229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5229-5229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -671,10 +672,10 @@
           </code>
           <div class="tip" id="1710">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5214-5214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5214-5214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -689,10 +690,10 @@
           </code>
           <div class="tip" id="1711">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5210-5210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5210-5210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -707,10 +708,10 @@
           </code>
           <div class="tip" id="1712">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5217-5217" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5217-5217" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="1713">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5216-5216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5216-5216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -743,10 +744,10 @@
           </code>
           <div class="tip" id="1714">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5230-5230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5230-5230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -761,10 +762,10 @@
           </code>
           <div class="tip" id="1715">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5220-5220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5220-5220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -779,10 +780,10 @@
           </code>
           <div class="tip" id="1716">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5211-5211" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5211-5211" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -797,10 +798,10 @@
           </code>
           <div class="tip" id="1717">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5226-5226" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5226-5226" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -815,10 +816,10 @@
           </code>
           <div class="tip" id="1718">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5209-5209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5209-5209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -833,10 +834,10 @@
           </code>
           <div class="tip" id="1719">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5227-5227" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5227-5227" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -851,10 +852,10 @@
           </code>
           <div class="tip" id="1720">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5215-5215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5215-5215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -869,10 +870,10 @@
           </code>
           <div class="tip" id="1721">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5219-5219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5219-5219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -887,10 +888,10 @@
           </code>
           <div class="tip" id="1722">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5232-5232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5232-5232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -905,10 +906,10 @@
           </code>
           <div class="tip" id="1723">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5207-5207" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5207-5207" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -923,10 +924,10 @@
           </code>
           <div class="tip" id="1724">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5213-5213" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5213-5213" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -941,10 +942,10 @@
           </code>
           <div class="tip" id="1725">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5208-5208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5208-5208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -959,10 +960,10 @@
           </code>
           <div class="tip" id="1726">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5218-5218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5218-5218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -977,10 +978,10 @@
           </code>
           <div class="tip" id="1727">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5221-5221" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5221-5221" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -995,10 +996,10 @@
           </code>
           <div class="tip" id="1728">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5223-5223" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5223-5223" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1013,10 +1014,10 @@
           </code>
           <div class="tip" id="1729">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5222-5222" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5222-5222" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1031,10 +1032,10 @@
           </code>
           <div class="tip" id="1730">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5231-5231" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5231-5231" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1049,10 +1050,10 @@
           </code>
           <div class="tip" id="1731">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5092-5092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5092-5092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1070,10 +1071,10 @@
           </code>
           <div class="tip" id="1732">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5092-5092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5092-5092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1091,10 +1092,10 @@
           </code>
           <div class="tip" id="1733">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5179-5179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5179-5179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1112,10 +1113,10 @@
           </code>
           <div class="tip" id="1734">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5179-5179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5179-5179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1133,10 +1134,10 @@
           </code>
           <div class="tip" id="1735">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5120-5120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5120-5120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1152,10 +1153,10 @@
           </code>
           <div class="tip" id="1736">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5120-5120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5120-5120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1171,10 +1172,10 @@
           </code>
           <div class="tip" id="1737">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5140-5140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5140-5140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1192,10 +1193,10 @@
           </code>
           <div class="tip" id="1738">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5140-5140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5140-5140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1213,10 +1214,10 @@
           </code>
           <div class="tip" id="1739">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5203-5203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5203-5203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1234,10 +1235,10 @@
           </code>
           <div class="tip" id="1740">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5203-5203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5203-5203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1255,10 +1256,10 @@
           </code>
           <div class="tip" id="1741">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5082-5082" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5082-5082" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1274,10 +1275,10 @@
           </code>
           <div class="tip" id="1742">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5082-5082" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5082-5082" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="1743">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5111-5111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5111-5111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1314,10 +1315,10 @@
           </code>
           <div class="tip" id="1744">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5111-5111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5111-5111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1335,10 +1336,10 @@
           </code>
           <div class="tip" id="1745">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5087-5087" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5087-5087" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1356,10 +1357,10 @@
           </code>
           <div class="tip" id="1746">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5087-5087" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5087-5087" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="1747">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5135-5135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5135-5135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1398,10 +1399,10 @@
           </code>
           <div class="tip" id="1748">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5135-5135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5135-5135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1419,10 +1420,10 @@
           </code>
           <div class="tip" id="1749">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5149-5149" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5149-5149" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1440,10 +1441,10 @@
           </code>
           <div class="tip" id="1750">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5149-5149" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5149-5149" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1461,10 +1462,10 @@
           </code>
           <div class="tip" id="1751">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5159-5159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5159-5159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1482,10 +1483,10 @@
           </code>
           <div class="tip" id="1752">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5159-5159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5159-5159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1503,10 +1504,10 @@
           </code>
           <div class="tip" id="1753">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5154-5154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5154-5154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1524,10 +1525,10 @@
           </code>
           <div class="tip" id="1754">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5154-5154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5154-5154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1545,10 +1546,10 @@
           </code>
           <div class="tip" id="1755">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5198-5198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5198-5198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1566,10 +1567,10 @@
           </code>
           <div class="tip" id="1756">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5198-5198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5198-5198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1591,7 +1592,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1654,6 +1655,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-colorbar.html
+++ b/docs/reference/xplot-plotly-graph-colorbar.html
@@ -5,7 +5,7 @@
     <title>Colorbar - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Colorbar</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1757">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1129-1129" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1129-1129" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1758">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1244-1244" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1244-1244" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1759">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1244-1244" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1244-1244" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1760">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1234-1234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1234-1234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1761">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1234-1234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1234-1234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1762">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1239-1239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1239-1239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="1763">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1239-1239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1239-1239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="1764">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1264-1264" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1264-1264" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="1765">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1264-1264" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1264-1264" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="1766">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1338-1338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1338-1338" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="1767">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1338-1338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1338-1338" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="1768">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1189-1189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1189-1189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="1769">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1189-1189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1189-1189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="1770">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1184-1184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1184-1184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -376,10 +377,10 @@
           </code>
           <div class="tip" id="1771">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1184-1184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1184-1184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -397,10 +398,10 @@
           </code>
           <div class="tip" id="1772">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1254-1254" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1254-1254" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -418,10 +419,10 @@
           </code>
           <div class="tip" id="1773">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1254-1254" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1254-1254" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="1774">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1224-1224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1224-1224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -460,10 +461,10 @@
           </code>
           <div class="tip" id="1775">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1224-1224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1224-1224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="1776">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1229-1229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1229-1229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="1777">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1229-1229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1229-1229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -523,10 +524,10 @@
           </code>
           <div class="tip" id="1778">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1389-1389" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1389-1389" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -541,10 +542,10 @@
           </code>
           <div class="tip" id="1779">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1387-1387" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1387-1387" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -559,10 +560,10 @@
           </code>
           <div class="tip" id="1780">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1388-1388" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1388-1388" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -577,10 +578,10 @@
           </code>
           <div class="tip" id="1781">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1393-1393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1393-1393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -595,10 +596,10 @@
           </code>
           <div class="tip" id="1782">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1408-1408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1408-1408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -613,10 +614,10 @@
           </code>
           <div class="tip" id="1783">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1378-1378" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1378-1378" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -631,10 +632,10 @@
           </code>
           <div class="tip" id="1784">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1377-1377" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1377-1377" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -649,10 +650,10 @@
           </code>
           <div class="tip" id="1785">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1391-1391" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1391-1391" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -667,10 +668,10 @@
           </code>
           <div class="tip" id="1786">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1385-1385" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1385-1385" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -685,10 +686,10 @@
           </code>
           <div class="tip" id="1787">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1386-1386" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1386-1386" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -703,10 +704,10 @@
           </code>
           <div class="tip" id="1788">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1409-1409" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1409-1409" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -721,10 +722,10 @@
           </code>
           <div class="tip" id="1789">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1400-1400" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1400-1400" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -739,10 +740,10 @@
           </code>
           <div class="tip" id="1790">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1405-1405" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1405-1405" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -757,10 +758,10 @@
           </code>
           <div class="tip" id="1791">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1407-1407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1407-1407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -775,10 +776,10 @@
           </code>
           <div class="tip" id="1792">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1376-1376" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1376-1376" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -793,10 +794,10 @@
           </code>
           <div class="tip" id="1793">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1375-1375" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1375-1375" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -811,10 +812,10 @@
           </code>
           <div class="tip" id="1794">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1392-1392" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1392-1392" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -829,10 +830,10 @@
           </code>
           <div class="tip" id="1795">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1402-1402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1402-1402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -847,10 +848,10 @@
           </code>
           <div class="tip" id="1796">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1399-1399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1399-1399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -865,10 +866,10 @@
           </code>
           <div class="tip" id="1797">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1401-1401" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1401-1401" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -883,10 +884,10 @@
           </code>
           <div class="tip" id="1798">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1403-1403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1403-1403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -901,10 +902,10 @@
           </code>
           <div class="tip" id="1799">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1397-1397" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1397-1397" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -919,10 +920,10 @@
           </code>
           <div class="tip" id="1800">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1390-1390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1390-1390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -937,10 +938,10 @@
           </code>
           <div class="tip" id="1801">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1404-1404" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1404-1404" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -955,10 +956,10 @@
           </code>
           <div class="tip" id="1802">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1396-1396" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1396-1396" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -973,10 +974,10 @@
           </code>
           <div class="tip" id="1803">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1406-1406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1406-1406" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -991,10 +992,10 @@
           </code>
           <div class="tip" id="1804">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1395-1395" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1395-1395" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1009,10 +1010,10 @@
           </code>
           <div class="tip" id="1805">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1415-1415" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1415-1415" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1027,10 +1028,10 @@
           </code>
           <div class="tip" id="1806">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1394-1394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1394-1394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1045,10 +1046,10 @@
           </code>
           <div class="tip" id="1807">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1414-1414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1414-1414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1063,10 +1064,10 @@
           </code>
           <div class="tip" id="1808">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1398-1398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1398-1398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1081,10 +1082,10 @@
           </code>
           <div class="tip" id="1809">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1410-1410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1410-1410" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1099,10 +1100,10 @@
           </code>
           <div class="tip" id="1810">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1411-1411" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1411-1411" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1117,10 +1118,10 @@
           </code>
           <div class="tip" id="1811">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1412-1412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1412-1412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1135,10 +1136,10 @@
           </code>
           <div class="tip" id="1812">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1379-1379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1379-1379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1153,10 +1154,10 @@
           </code>
           <div class="tip" id="1813">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1380-1380" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1380-1380" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1171,10 +1172,10 @@
           </code>
           <div class="tip" id="1814">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1381-1381" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1381-1381" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1189,10 +1190,10 @@
           </code>
           <div class="tip" id="1815">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1382-1382" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1382-1382" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1207,10 +1208,10 @@
           </code>
           <div class="tip" id="1816">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1383-1383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1383-1383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1225,10 +1226,10 @@
           </code>
           <div class="tip" id="1817">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1384-1384" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1384-1384" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1243,10 +1244,10 @@
           </code>
           <div class="tip" id="1818">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1343-1343" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1343-1343" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1264,10 +1265,10 @@
           </code>
           <div class="tip" id="1819">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1343-1343" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1343-1343" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1285,10 +1286,10 @@
           </code>
           <div class="tip" id="1820">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1299-1299" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1299-1299" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1306,10 +1307,10 @@
           </code>
           <div class="tip" id="1821">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1299-1299" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1299-1299" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1327,10 +1328,10 @@
           </code>
           <div class="tip" id="1822">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1323-1323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1323-1323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1348,10 +1349,10 @@
           </code>
           <div class="tip" id="1823">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1323-1323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1323-1323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1369,10 +1370,10 @@
           </code>
           <div class="tip" id="1824">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1333-1333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1333-1333" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1390,10 +1391,10 @@
           </code>
           <div class="tip" id="1825">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1333-1333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1333-1333" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1411,10 +1412,10 @@
           </code>
           <div class="tip" id="1826">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1179-1179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1179-1179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1432,10 +1433,10 @@
           </code>
           <div class="tip" id="1827">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1179-1179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1179-1179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1453,10 +1454,10 @@
           </code>
           <div class="tip" id="1828">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1174-1174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1174-1174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1474,10 +1475,10 @@
           </code>
           <div class="tip" id="1829">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1174-1174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1174-1174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1495,10 +1496,10 @@
           </code>
           <div class="tip" id="1830">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1259-1259" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1259-1259" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1516,10 +1517,10 @@
           </code>
           <div class="tip" id="1831">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1259-1259" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1259-1259" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1537,10 +1538,10 @@
           </code>
           <div class="tip" id="1832">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1308-1308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1308-1308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1558,10 +1559,10 @@
           </code>
           <div class="tip" id="1833">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1308-1308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1308-1308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1579,10 +1580,10 @@
           </code>
           <div class="tip" id="1834">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1294-1294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1294-1294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1600,10 +1601,10 @@
           </code>
           <div class="tip" id="1835">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1294-1294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1294-1294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1621,10 +1622,10 @@
           </code>
           <div class="tip" id="1836">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1303-1303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1303-1303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1640,10 +1641,10 @@
           </code>
           <div class="tip" id="1837">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1303-1303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1303-1303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1659,10 +1660,10 @@
           </code>
           <div class="tip" id="1838">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1313-1313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1313-1313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1680,10 +1681,10 @@
           </code>
           <div class="tip" id="1839">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1313-1313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1313-1313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1701,10 +1702,10 @@
           </code>
           <div class="tip" id="1840">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1284-1284" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1284-1284" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1722,10 +1723,10 @@
           </code>
           <div class="tip" id="1841">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1284-1284" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1284-1284" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1743,10 +1744,10 @@
           </code>
           <div class="tip" id="1842">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1249-1249" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1249-1249" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1764,10 +1765,10 @@
           </code>
           <div class="tip" id="1843">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1249-1249" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1249-1249" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1785,10 +1786,10 @@
           </code>
           <div class="tip" id="1844">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1318-1318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1318-1318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1806,10 +1807,10 @@
           </code>
           <div class="tip" id="1845">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1318-1318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1318-1318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1827,10 +1828,10 @@
           </code>
           <div class="tip" id="1846">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1279-1279" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1279-1279" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1848,10 +1849,10 @@
           </code>
           <div class="tip" id="1847">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1279-1279" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1279-1279" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1869,10 +1870,10 @@
           </code>
           <div class="tip" id="1848">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1328-1328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1328-1328" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1890,10 +1891,10 @@
           </code>
           <div class="tip" id="1849">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1328-1328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1328-1328" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1911,10 +1912,10 @@
           </code>
           <div class="tip" id="1850">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1274-1274" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1274-1274" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1932,10 +1933,10 @@
           </code>
           <div class="tip" id="1851">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1274-1274" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1274-1274" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1953,10 +1954,10 @@
           </code>
           <div class="tip" id="1852">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1371-1371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1371-1371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1974,10 +1975,10 @@
           </code>
           <div class="tip" id="1853">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1371-1371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1371-1371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1995,10 +1996,10 @@
           </code>
           <div class="tip" id="1854">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1269-1269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1269-1269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2016,10 +2017,10 @@
           </code>
           <div class="tip" id="1855">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1269-1269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1269-1269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2037,10 +2038,10 @@
           </code>
           <div class="tip" id="1856">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1366-1366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1366-1366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2058,10 +2059,10 @@
           </code>
           <div class="tip" id="1857">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1366-1366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1366-1366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2079,10 +2080,10 @@
           </code>
           <div class="tip" id="1858">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1289-1289" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1289-1289" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2100,10 +2101,10 @@
           </code>
           <div class="tip" id="1859">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1289-1289" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1289-1289" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2121,10 +2122,10 @@
           </code>
           <div class="tip" id="1860">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1348-1348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1348-1348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2142,10 +2143,10 @@
           </code>
           <div class="tip" id="1861">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1348-1348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1348-1348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2163,10 +2164,10 @@
           </code>
           <div class="tip" id="1862">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1352-1352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1352-1352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2182,10 +2183,10 @@
           </code>
           <div class="tip" id="1863">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1352-1352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1352-1352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2201,10 +2202,10 @@
           </code>
           <div class="tip" id="1864">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1357-1357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1357-1357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2222,10 +2223,10 @@
           </code>
           <div class="tip" id="1865">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1357-1357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1357-1357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2243,10 +2244,10 @@
           </code>
           <div class="tip" id="1866">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1194-1194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1194-1194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2264,10 +2265,10 @@
           </code>
           <div class="tip" id="1867">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1194-1194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1194-1194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2285,10 +2286,10 @@
           </code>
           <div class="tip" id="1868">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1199-1199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1199-1199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2306,10 +2307,10 @@
           </code>
           <div class="tip" id="1869">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1199-1199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1199-1199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2327,10 +2328,10 @@
           </code>
           <div class="tip" id="1870">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1204-1204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1204-1204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2348,10 +2349,10 @@
           </code>
           <div class="tip" id="1871">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1204-1204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1204-1204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2369,10 +2370,10 @@
           </code>
           <div class="tip" id="1872">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1209-1209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1209-1209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2390,10 +2391,10 @@
           </code>
           <div class="tip" id="1873">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1209-1209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1209-1209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2411,10 +2412,10 @@
           </code>
           <div class="tip" id="1874">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1214-1214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1214-1214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2432,10 +2433,10 @@
           </code>
           <div class="tip" id="1875">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1214-1214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1214-1214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2453,10 +2454,10 @@
           </code>
           <div class="tip" id="1876">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1219-1219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1219-1219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2474,10 +2475,10 @@
           </code>
           <div class="tip" id="1877">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1219-1219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1219-1219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2499,7 +2500,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2562,6 +2563,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-contour.html
+++ b/docs/reference/xplot-plotly-graph-contour.html
@@ -5,7 +5,7 @@
     <title>Contour - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Contour</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="1878">
             <strong>Signature:</strong> unit -&gt; Contour<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3565-3565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3565-3565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="1879">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3731-3731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3731-3731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="1880">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3731-3731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3731-3731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="1881">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3760-3760" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3760-3760" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="1882">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3760-3760" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3760-3760" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="1883">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3811-3811" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3811-3811" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -206,10 +207,10 @@
           </code>
           <div class="tip" id="1884">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3811-3811" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3811-3811" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="1885">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3755-3755" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3755-3755" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="1886">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3755-3755" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3755-3755" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="1887">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3726-3726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3726-3726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -284,10 +285,10 @@
           </code>
           <div class="tip" id="1888">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3726-3726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3726-3726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="1889">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3751-3751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3751-3751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="1890">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3751-3751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3751-3751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="1891">
             <strong>Signature:</strong> unit -&gt; Contours<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3769-3769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3769-3769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -366,10 +367,10 @@
           </code>
           <div class="tip" id="1892">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3769-3769" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3769-3769" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -385,10 +386,10 @@
           </code>
           <div class="tip" id="1893">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3671-3671" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3671-3671" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -406,10 +407,10 @@
           </code>
           <div class="tip" id="1894">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3671-3671" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3671-3671" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -427,10 +428,10 @@
           </code>
           <div class="tip" id="1895">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3686-3686" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3686-3686" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -448,10 +449,10 @@
           </code>
           <div class="tip" id="1896">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3686-3686" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3686-3686" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -469,10 +470,10 @@
           </code>
           <div class="tip" id="1897">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3647-3647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3647-3647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -490,10 +491,10 @@
           </code>
           <div class="tip" id="1898">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3647-3647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3647-3647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +512,10 @@
           </code>
           <div class="tip" id="1899">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3628-3628" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3628-3628" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -532,10 +533,10 @@
           </code>
           <div class="tip" id="1900">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3628-3628" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3628-3628" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="1901">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3773-3773" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3773-3773" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -572,10 +573,10 @@
           </code>
           <div class="tip" id="1902">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3773-3773" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3773-3773" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="1903">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3765-3765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3765-3765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -612,10 +613,10 @@
           </code>
           <div class="tip" id="1904">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3765-3765" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3765-3765" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="1905">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3633-3633" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3633-3633" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="1906">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3633-3633" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3633-3633" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="1907">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3736-3736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3736-3736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -696,10 +697,10 @@
           </code>
           <div class="tip" id="1908">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3736-3736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3736-3736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="1909">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3847-3847" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3847-3847" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="1910">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3853-3853" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3853-3853" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -753,10 +754,10 @@
           </code>
           <div class="tip" id="1911">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3864-3864" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3864-3864" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -771,10 +772,10 @@
           </code>
           <div class="tip" id="1912">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3852-3852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3852-3852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -789,10 +790,10 @@
           </code>
           <div class="tip" id="1913">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3846-3846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3846-3846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -807,10 +808,10 @@
           </code>
           <div class="tip" id="1914">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3851-3851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3851-3851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="1915">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3855-3855" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3855-3855" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="1916">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3835-3835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3835-3835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="1917">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3838-3838" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3838-3838" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="1918">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3830-3830" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3830-3830" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -897,10 +898,10 @@
           </code>
           <div class="tip" id="1919">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3826-3826" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3826-3826" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -915,10 +916,10 @@
           </code>
           <div class="tip" id="1920">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3856-3856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3856-3856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="1921">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3854-3854" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3854-3854" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -951,10 +952,10 @@
           </code>
           <div class="tip" id="1922">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3827-3827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3827-3827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="1923">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3848-3848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3848-3848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -987,10 +988,10 @@
           </code>
           <div class="tip" id="1924">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3863-3863" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3863-3863" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="1925">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3825-3825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3825-3825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1023,10 +1024,10 @@
           </code>
           <div class="tip" id="1926">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3849-3849" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3849-3849" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1041,10 +1042,10 @@
           </code>
           <div class="tip" id="1927">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3831-3831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3831-3831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1059,10 +1060,10 @@
           </code>
           <div class="tip" id="1928">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3839-3839" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3839-3839" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1077,10 +1078,10 @@
           </code>
           <div class="tip" id="1929">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3862-3862" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3862-3862" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1095,10 +1096,10 @@
           </code>
           <div class="tip" id="1930">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3840-3840" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3840-3840" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1113,10 +1114,10 @@
           </code>
           <div class="tip" id="1931">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3823-3823" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3823-3823" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1131,10 +1132,10 @@
           </code>
           <div class="tip" id="1932">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3829-3829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3829-3829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1149,10 +1150,10 @@
           </code>
           <div class="tip" id="1933">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3824-3824" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3824-3824" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1167,10 +1168,10 @@
           </code>
           <div class="tip" id="1934">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3865-3865" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3865-3865" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1185,10 +1186,10 @@
           </code>
           <div class="tip" id="1935">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3833-3833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3833-3833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1203,10 +1204,10 @@
           </code>
           <div class="tip" id="1936">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3834-3834" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3834-3834" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1221,10 +1222,10 @@
           </code>
           <div class="tip" id="1937">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3857-3857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3857-3857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1239,10 +1240,10 @@
           </code>
           <div class="tip" id="1938">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3860-3860" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3860-3860" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1257,10 +1258,10 @@
           </code>
           <div class="tip" id="1939">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3841-3841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3841-3841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1275,10 +1276,10 @@
           </code>
           <div class="tip" id="1940">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3836-3836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3836-3836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="1941">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3837-3837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3837-3837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1311,10 +1312,10 @@
           </code>
           <div class="tip" id="1942">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3858-3858" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3858-3858" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1329,10 +1330,10 @@
           </code>
           <div class="tip" id="1943">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3861-3861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3861-3861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1347,10 +1348,10 @@
           </code>
           <div class="tip" id="1944">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3842-3842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3842-3842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1365,10 +1366,10 @@
           </code>
           <div class="tip" id="1945">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3832-3832" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3832-3832" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1383,10 +1384,10 @@
           </code>
           <div class="tip" id="1946">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3843-3843" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3843-3843" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1401,10 +1402,10 @@
           </code>
           <div class="tip" id="1947">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3845-3845" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3845-3845" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1419,10 +1420,10 @@
           </code>
           <div class="tip" id="1948">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3844-3844" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3844-3844" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1437,10 +1438,10 @@
           </code>
           <div class="tip" id="1949">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3850-3850" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3850-3850" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1455,10 +1456,10 @@
           </code>
           <div class="tip" id="1950">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3859-3859" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3859-3859" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1473,10 +1474,10 @@
           </code>
           <div class="tip" id="1951">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3807-3807" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3807-3807" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1492,10 +1493,10 @@
           </code>
           <div class="tip" id="1952">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3807-3807" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3807-3807" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1511,10 +1512,10 @@
           </code>
           <div class="tip" id="1953">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3623-3623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3623-3623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1532,10 +1533,10 @@
           </code>
           <div class="tip" id="1954">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3623-3623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3623-3623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1553,10 +1554,10 @@
           </code>
           <div class="tip" id="1955">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3741-3741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3741-3741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1574,10 +1575,10 @@
           </code>
           <div class="tip" id="1956">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3741-3741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3741-3741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1595,10 +1596,10 @@
           </code>
           <div class="tip" id="1957">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3651-3651" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3651-3651" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1614,10 +1615,10 @@
           </code>
           <div class="tip" id="1958">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3651-3651" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3651-3651" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1633,10 +1634,10 @@
           </code>
           <div class="tip" id="1959">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3691-3691" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3691-3691" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1654,10 +1655,10 @@
           </code>
           <div class="tip" id="1960">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3691-3691" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3691-3691" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1675,10 +1676,10 @@
           </code>
           <div class="tip" id="1961">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3803-3803" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3803-3803" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1696,10 +1697,10 @@
           </code>
           <div class="tip" id="1962">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3803-3803" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3803-3803" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1717,10 +1718,10 @@
           </code>
           <div class="tip" id="1963">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3696-3696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3696-3696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1738,10 +1739,10 @@
           </code>
           <div class="tip" id="1964">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3696-3696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3696-3696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1759,10 +1760,10 @@
           </code>
           <div class="tip" id="1965">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3613-3613" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3613-3613" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1778,10 +1779,10 @@
           </code>
           <div class="tip" id="1966">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3613-3613" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3613-3613" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1797,10 +1798,10 @@
           </code>
           <div class="tip" id="1967">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3642-3642" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3642-3642" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1818,10 +1819,10 @@
           </code>
           <div class="tip" id="1968">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3642-3642" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3642-3642" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1839,10 +1840,10 @@
           </code>
           <div class="tip" id="1969">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3618-3618" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3618-3618" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1860,10 +1861,10 @@
           </code>
           <div class="tip" id="1970">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3618-3618" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3618-3618" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1881,10 +1882,10 @@
           </code>
           <div class="tip" id="1971">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3815-3815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3815-3815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1900,10 +1901,10 @@
           </code>
           <div class="tip" id="1972">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3815-3815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3815-3815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1919,10 +1920,10 @@
           </code>
           <div class="tip" id="1973">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3661-3661" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3661-3661" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1940,10 +1941,10 @@
           </code>
           <div class="tip" id="1974">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3661-3661" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3661-3661" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1961,10 +1962,10 @@
           </code>
           <div class="tip" id="1975">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3666-3666" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3666-3666" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1982,10 +1983,10 @@
           </code>
           <div class="tip" id="1976">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3666-3666" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3666-3666" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2003,10 +2004,10 @@
           </code>
           <div class="tip" id="1977">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3778-3778" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3778-3778" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2024,10 +2025,10 @@
           </code>
           <div class="tip" id="1978">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3778-3778" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3778-3778" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2045,10 +2046,10 @@
           </code>
           <div class="tip" id="1979">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3793-3793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3793-3793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2066,10 +2067,10 @@
           </code>
           <div class="tip" id="1980">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3793-3793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3793-3793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2087,10 +2088,10 @@
           </code>
           <div class="tip" id="1981">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3701-3701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3701-3701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2108,10 +2109,10 @@
           </code>
           <div class="tip" id="1982">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3701-3701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3701-3701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2129,10 +2130,10 @@
           </code>
           <div class="tip" id="1983">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3676-3676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3676-3676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2150,10 +2151,10 @@
           </code>
           <div class="tip" id="1984">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3676-3676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3676-3676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2171,10 +2172,10 @@
           </code>
           <div class="tip" id="1985">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3681-3681" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3681-3681" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2192,10 +2193,10 @@
           </code>
           <div class="tip" id="1986">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3681-3681" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3681-3681" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2213,10 +2214,10 @@
           </code>
           <div class="tip" id="1987">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3783-3783" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3783-3783" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2234,10 +2235,10 @@
           </code>
           <div class="tip" id="1988">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3783-3783" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3783-3783" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2255,10 +2256,10 @@
           </code>
           <div class="tip" id="1989">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3798-3798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3798-3798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2276,10 +2277,10 @@
           </code>
           <div class="tip" id="1990">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3798-3798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3798-3798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2297,10 +2298,10 @@
           </code>
           <div class="tip" id="1991">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3706-3706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3706-3706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2318,10 +2319,10 @@
           </code>
           <div class="tip" id="1992">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3706-3706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3706-3706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2339,10 +2340,10 @@
           </code>
           <div class="tip" id="1993">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3656-3656" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3656-3656" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2360,10 +2361,10 @@
           </code>
           <div class="tip" id="1994">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3656-3656" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3656-3656" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2381,10 +2382,10 @@
           </code>
           <div class="tip" id="1995">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3711-3711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3711-3711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2402,10 +2403,10 @@
           </code>
           <div class="tip" id="1996">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3711-3711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3711-3711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2423,10 +2424,10 @@
           </code>
           <div class="tip" id="1997">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3721-3721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3721-3721" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2444,10 +2445,10 @@
           </code>
           <div class="tip" id="1998">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3721-3721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3721-3721" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2465,10 +2466,10 @@
           </code>
           <div class="tip" id="1999">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3716-3716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3716-3716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2486,10 +2487,10 @@
           </code>
           <div class="tip" id="2000">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3716-3716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3716-3716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2507,10 +2508,10 @@
           </code>
           <div class="tip" id="2001">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3746-3746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3746-3746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2528,10 +2529,10 @@
           </code>
           <div class="tip" id="2002">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3746-3746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3746-3746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2549,10 +2550,10 @@
           </code>
           <div class="tip" id="2003">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3788-3788" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3788-3788" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2570,10 +2571,10 @@
           </code>
           <div class="tip" id="2004">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3788-3788" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3788-3788" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2595,7 +2596,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2658,6 +2659,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-contours.html
+++ b/docs/reference/xplot-plotly-graph-contours.html
@@ -5,7 +5,7 @@
     <title>Contours - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Contours</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2005">
             <strong>Signature:</strong> unit -&gt; Contours<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L547-547" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L547-547" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2006">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L575-575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L575-575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2007">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L575-575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L575-575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2008">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L565-565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L565-565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2009">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L565-565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L565-565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2010">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L603-603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L603-603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -205,10 +206,10 @@
           </code>
           <div class="tip" id="2011">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L601-601" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L601-601" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -223,10 +224,10 @@
           </code>
           <div class="tip" id="2012">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L604-604" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L604-604" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -241,10 +242,10 @@
           </code>
           <div class="tip" id="2013">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L602-602" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L602-602" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -259,10 +260,10 @@
           </code>
           <div class="tip" id="2014">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L600-600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L600-600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -277,10 +278,10 @@
           </code>
           <div class="tip" id="2015">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L606-606" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L606-606" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -295,10 +296,10 @@
           </code>
           <div class="tip" id="2016">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L607-607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L607-607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2017">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L608-608" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L608-608" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -331,10 +332,10 @@
           </code>
           <div class="tip" id="2018">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L580-580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L580-580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -352,10 +353,10 @@
           </code>
           <div class="tip" id="2019">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L580-580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L580-580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -373,10 +374,10 @@
           </code>
           <div class="tip" id="2020">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L570-570" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L570-570" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -394,10 +395,10 @@
           </code>
           <div class="tip" id="2021">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L570-570" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L570-570" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -415,10 +416,10 @@
           </code>
           <div class="tip" id="2022">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L560-560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L560-560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -436,10 +437,10 @@
           </code>
           <div class="tip" id="2023">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L560-560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L560-560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="2024">
             <strong>Signature:</strong> unit -&gt; X<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L588-588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L588-588" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -476,10 +477,10 @@
           </code>
           <div class="tip" id="2025">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L588-588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L588-588" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -495,10 +496,10 @@
           </code>
           <div class="tip" id="2026">
             <strong>Signature:</strong> unit -&gt; Y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L592-592" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L592-592" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -514,10 +515,10 @@
           </code>
           <div class="tip" id="2027">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L592-592" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L592-592" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="2028">
             <strong>Signature:</strong> unit -&gt; Z<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L596-596" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L596-596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -552,10 +553,10 @@
           </code>
           <div class="tip" id="2029">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L596-596" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L596-596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -575,7 +576,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -638,6 +639,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-domain.html
+++ b/docs/reference/xplot-plotly-graph-domain.html
@@ -5,7 +5,7 @@
     <title>Domain - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Domain</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2030">
             <strong>Signature:</strong> unit -&gt; Domain<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L680-680" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L680-680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2031">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L700-700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L700-700" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="2032">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L701-701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L701-701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="2033">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L687-687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L687-687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="2034">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L687-687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L687-687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -181,10 +182,10 @@
           </code>
           <div class="tip" id="2035">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L692-692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L692-692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -202,10 +203,10 @@
           </code>
           <div class="tip" id="2036">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L692-692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L692-692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -227,7 +228,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -290,6 +291,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-error_x.html
+++ b/docs/reference/xplot-plotly-graph-error_x.html
@@ -5,7 +5,7 @@
     <title>Error_x - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Error_x</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2037">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L884-884" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L884-884" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2038">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L920-920" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L920-920" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2039">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L920-920" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L920-920" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2040">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L925-925" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L925-925" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2041">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L925-925" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L925-925" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2042">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L980-980" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L980-980" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2043">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L980-980" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L980-980" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2044">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L975-975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L975-975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2045">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L975-975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L975-975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2046">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L956-956" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L956-956" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="2047">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L956-956" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L956-956" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2048">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L947-947" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L947-947" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="2049">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L947-947" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L947-947" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2050">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L951-951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L951-951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -370,10 +371,10 @@
           </code>
           <div class="tip" id="2051">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L951-951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L951-951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="2052">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L987-987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L987-987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="2053">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L988-988" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L988-988" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -425,10 +426,10 @@
           </code>
           <div class="tip" id="2054">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1000-1000" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1000-1000" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,10 +444,10 @@
           </code>
           <div class="tip" id="2055">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L999-999" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L999-999" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="2056">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L995-995" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L995-995" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -479,10 +480,10 @@
           </code>
           <div class="tip" id="2057">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L993-993" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L993-993" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +498,10 @@
           </code>
           <div class="tip" id="2058">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L994-994" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L994-994" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2059">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L986-986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L986-986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="2060">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L996-996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L996-996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +552,10 @@
           </code>
           <div class="tip" id="2061">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L991-991" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L991-991" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -569,10 +570,10 @@
           </code>
           <div class="tip" id="2062">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L992-992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L992-992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -587,10 +588,10 @@
           </code>
           <div class="tip" id="2063">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L985-985" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L985-985" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -605,10 +606,10 @@
           </code>
           <div class="tip" id="2064">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L989-989" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L989-989" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -623,10 +624,10 @@
           </code>
           <div class="tip" id="2065">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L990-990" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L990-990" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2066">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L984-984" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L984-984" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -659,10 +660,10 @@
           </code>
           <div class="tip" id="2067">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L997-997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L997-997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -677,10 +678,10 @@
           </code>
           <div class="tip" id="2068">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L915-915" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L915-915" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -698,10 +699,10 @@
           </code>
           <div class="tip" id="2069">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L915-915" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L915-915" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -719,10 +720,10 @@
           </code>
           <div class="tip" id="2070">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L961-961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L961-961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -740,10 +741,10 @@
           </code>
           <div class="tip" id="2071">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L961-961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L961-961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -761,10 +762,10 @@
           </code>
           <div class="tip" id="2072">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L939-939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L939-939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -780,10 +781,10 @@
           </code>
           <div class="tip" id="2073">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L939-939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L939-939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -799,10 +800,10 @@
           </code>
           <div class="tip" id="2074">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L943-943" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L943-943" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -818,10 +819,10 @@
           </code>
           <div class="tip" id="2075">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L943-943" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L943-943" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -837,10 +838,10 @@
           </code>
           <div class="tip" id="2076">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L910-910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L910-910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -858,10 +859,10 @@
           </code>
           <div class="tip" id="2077">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L910-910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L910-910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="2078">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L930-930" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L930-930" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -900,10 +901,10 @@
           </code>
           <div class="tip" id="2079">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L930-930" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L930-930" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -921,10 +922,10 @@
           </code>
           <div class="tip" id="2080">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L935-935" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L935-935" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -942,10 +943,10 @@
           </code>
           <div class="tip" id="2081">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L935-935" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L935-935" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -963,10 +964,10 @@
           </code>
           <div class="tip" id="2082">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L905-905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L905-905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -984,10 +985,10 @@
           </code>
           <div class="tip" id="2083">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L905-905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L905-905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="2084">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L966-966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L966-966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1026,10 +1027,10 @@
           </code>
           <div class="tip" id="2085">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L966-966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L966-966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1051,7 +1052,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1114,6 +1115,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-error_y.html
+++ b/docs/reference/xplot-plotly-graph-error_y.html
@@ -5,7 +5,7 @@
     <title>Error_y - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Error_y</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2086">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L766-766" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L766-766" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2087">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L802-802" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L802-802" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2088">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L802-802" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L802-802" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2089">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L807-807" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L807-807" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2090">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L807-807" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L807-807" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2091">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L862-862" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L862-862" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2092">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L862-862" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L862-862" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2093">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L857-857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L857-857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2094">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L857-857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L857-857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2095">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L838-838" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L838-838" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="2096">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L838-838" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L838-838" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2097">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L829-829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L829-829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="2098">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L829-829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L829-829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2099">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L833-833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L833-833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -370,10 +371,10 @@
           </code>
           <div class="tip" id="2100">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L833-833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L833-833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="2101">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L869-869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L869-869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="2102">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L870-870" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L870-870" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -425,10 +426,10 @@
           </code>
           <div class="tip" id="2103">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L882-882" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L882-882" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,10 +444,10 @@
           </code>
           <div class="tip" id="2104">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L881-881" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L881-881" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="2105">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L877-877" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L877-877" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -479,10 +480,10 @@
           </code>
           <div class="tip" id="2106">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L875-875" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L875-875" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +498,10 @@
           </code>
           <div class="tip" id="2107">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L876-876" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L876-876" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2108">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L868-868" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L868-868" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="2109">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L878-878" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L878-878" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +552,10 @@
           </code>
           <div class="tip" id="2110">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L873-873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L873-873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -569,10 +570,10 @@
           </code>
           <div class="tip" id="2111">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L874-874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L874-874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -587,10 +588,10 @@
           </code>
           <div class="tip" id="2112">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L867-867" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L867-867" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -605,10 +606,10 @@
           </code>
           <div class="tip" id="2113">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L871-871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L871-871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -623,10 +624,10 @@
           </code>
           <div class="tip" id="2114">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L872-872" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L872-872" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2115">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L866-866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L866-866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -659,10 +660,10 @@
           </code>
           <div class="tip" id="2116">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L879-879" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L879-879" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -677,10 +678,10 @@
           </code>
           <div class="tip" id="2117">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L797-797" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L797-797" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -698,10 +699,10 @@
           </code>
           <div class="tip" id="2118">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L797-797" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L797-797" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -719,10 +720,10 @@
           </code>
           <div class="tip" id="2119">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L843-843" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L843-843" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -740,10 +741,10 @@
           </code>
           <div class="tip" id="2120">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L843-843" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L843-843" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -761,10 +762,10 @@
           </code>
           <div class="tip" id="2121">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L821-821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L821-821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -780,10 +781,10 @@
           </code>
           <div class="tip" id="2122">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L821-821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L821-821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -799,10 +800,10 @@
           </code>
           <div class="tip" id="2123">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L825-825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L825-825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -818,10 +819,10 @@
           </code>
           <div class="tip" id="2124">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L825-825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L825-825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -837,10 +838,10 @@
           </code>
           <div class="tip" id="2125">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L792-792" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L792-792" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -858,10 +859,10 @@
           </code>
           <div class="tip" id="2126">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L792-792" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L792-792" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="2127">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L812-812" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L812-812" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -900,10 +901,10 @@
           </code>
           <div class="tip" id="2128">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L812-812" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L812-812" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -921,10 +922,10 @@
           </code>
           <div class="tip" id="2129">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L817-817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L817-817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -942,10 +943,10 @@
           </code>
           <div class="tip" id="2130">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L817-817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L817-817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -963,10 +964,10 @@
           </code>
           <div class="tip" id="2131">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L787-787" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L787-787" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -984,10 +985,10 @@
           </code>
           <div class="tip" id="2132">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L787-787" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L787-787" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="2133">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L848-848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L848-848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1026,10 +1027,10 @@
           </code>
           <div class="tip" id="2134">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L848-848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L848-848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1051,7 +1052,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1114,6 +1115,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-error_z.html
+++ b/docs/reference/xplot-plotly-graph-error_z.html
@@ -5,7 +5,7 @@
     <title>Error_z - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Error_z</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2135">
             <strong>Signature:</strong> unit -&gt; Error_z<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L124-124" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L124-124" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2136">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L160-160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L160-160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2137">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L160-160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L160-160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2138">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2139">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2140">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2141">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L220-220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L220-220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2142">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L215-215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L215-215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2143">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L215-215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L215-215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2144">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L196-196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L196-196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="2145">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L196-196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L196-196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2146">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L187-187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L187-187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="2147">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L187-187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L187-187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2148">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L191-191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -370,10 +371,10 @@
           </code>
           <div class="tip" id="2149">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L191-191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="2150">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L227-227" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L227-227" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="2151">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L228-228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L228-228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -425,10 +426,10 @@
           </code>
           <div class="tip" id="2152">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L240-240" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L240-240" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,10 +444,10 @@
           </code>
           <div class="tip" id="2153">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L239-239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L239-239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="2154">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L235-235" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L235-235" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -479,10 +480,10 @@
           </code>
           <div class="tip" id="2155">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L233-233" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L233-233" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +498,10 @@
           </code>
           <div class="tip" id="2156">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L234-234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L234-234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2157">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L226-226" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L226-226" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="2158">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L236-236" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L236-236" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +552,10 @@
           </code>
           <div class="tip" id="2159">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L231-231" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L231-231" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -569,10 +570,10 @@
           </code>
           <div class="tip" id="2160">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L232-232" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L232-232" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -587,10 +588,10 @@
           </code>
           <div class="tip" id="2161">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L225-225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L225-225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -605,10 +606,10 @@
           </code>
           <div class="tip" id="2162">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L229-229" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L229-229" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -623,10 +624,10 @@
           </code>
           <div class="tip" id="2163">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L230-230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L230-230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2164">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L224-224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L224-224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -659,10 +660,10 @@
           </code>
           <div class="tip" id="2165">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L237-237" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L237-237" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -677,10 +678,10 @@
           </code>
           <div class="tip" id="2166">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L155-155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L155-155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -698,10 +699,10 @@
           </code>
           <div class="tip" id="2167">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L155-155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L155-155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -719,10 +720,10 @@
           </code>
           <div class="tip" id="2168">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L201-201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L201-201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -740,10 +741,10 @@
           </code>
           <div class="tip" id="2169">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L201-201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L201-201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -761,10 +762,10 @@
           </code>
           <div class="tip" id="2170">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L179-179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L179-179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -780,10 +781,10 @@
           </code>
           <div class="tip" id="2171">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L179-179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L179-179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -799,10 +800,10 @@
           </code>
           <div class="tip" id="2172">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L183-183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L183-183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -818,10 +819,10 @@
           </code>
           <div class="tip" id="2173">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L183-183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L183-183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -837,10 +838,10 @@
           </code>
           <div class="tip" id="2174">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L150-150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L150-150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -858,10 +859,10 @@
           </code>
           <div class="tip" id="2175">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L150-150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L150-150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="2176">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L170-170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L170-170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -900,10 +901,10 @@
           </code>
           <div class="tip" id="2177">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L170-170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L170-170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -921,10 +922,10 @@
           </code>
           <div class="tip" id="2178">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L175-175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L175-175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -942,10 +943,10 @@
           </code>
           <div class="tip" id="2179">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L175-175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L175-175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -963,10 +964,10 @@
           </code>
           <div class="tip" id="2180">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L145-145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L145-145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -984,10 +985,10 @@
           </code>
           <div class="tip" id="2181">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L145-145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L145-145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="2182">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L206-206" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L206-206" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1026,10 +1027,10 @@
           </code>
           <div class="tip" id="2183">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L206-206" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L206-206" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1051,7 +1052,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1114,6 +1115,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-eye.html
+++ b/docs/reference/xplot-plotly-graph-eye.html
@@ -5,7 +5,7 @@
     <title>Eye - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Eye</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2184">
             <strong>Signature:</strong> unit -&gt; Eye<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6420-6420" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6420-6420" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2185">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6448-6448" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6448-6448" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="2186">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6449-6449" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6449-6449" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="2187">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6450-6450" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6450-6450" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="2188">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6428-6428" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6428-6428" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -176,10 +177,10 @@
           </code>
           <div class="tip" id="2189">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6428-6428" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6428-6428" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="2190">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6432-6432" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6432-6432" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="2191">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6432-6432" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6432-6432" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="2192">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6436-6436" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6436-6436" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="2193">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6436-6436" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6436-6436" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-font.html
+++ b/docs/reference/xplot-plotly-graph-font.html
@@ -5,7 +5,7 @@
     <title>Font - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Font</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2194">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L15-15" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L15-15" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2195">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L32-32" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L32-32" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2196">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L32-32" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L32-32" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2197">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L24-24" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L24-24" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="2198">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L24-24" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L24-24" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="2199">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L47-47" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L47-47" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="2200">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L45-45" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L45-45" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="2201">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L46-46" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L46-46" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="2202">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L28-28" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L28-28" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -256,10 +257,10 @@
           </code>
           <div class="tip" id="2203">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L28-28" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L28-28" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-geo.html
+++ b/docs/reference/xplot-plotly-graph-geo.html
@@ -5,7 +5,7 @@
     <title>Geo - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Geo</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2204">
             <strong>Signature:</strong> unit -&gt; Geo<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7022-7022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7022-7022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2205">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7191-7191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7191-7191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2206">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7191-7191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7191-7191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2207">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7179-7179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7179-7179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="2208">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7179-7179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7179-7179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="2209">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7079-7079" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7079-7079" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="2210">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7079-7079" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7079-7079" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="2211">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7084-7084" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7084-7084" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="2212">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7084-7084" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7084-7084" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="2213">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7139-7139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7139-7139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="2214">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7139-7139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7139-7139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2215">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7144-7144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7144-7144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="2216">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7144-7144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7144-7144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2217">
             <strong>Signature:</strong> unit -&gt; Domain<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7055-7055" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7055-7055" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -370,10 +371,10 @@
           </code>
           <div class="tip" id="2218">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7055-7055" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7055-7055" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="2219">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7169-7169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7169-7169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="2220">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7169-7169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7169-7169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="2221">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7174-7174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7174-7174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="2222">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7174-7174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7174-7174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="2223">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7114-7114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7114-7114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="2224">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7114-7114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7114-7114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2225">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7094-7094" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7094-7094" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="2226">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7094-7094" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7094-7094" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="2227">
             <strong>Signature:</strong> unit -&gt; Lataxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7187-7187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7187-7187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -576,10 +577,10 @@
           </code>
           <div class="tip" id="2228">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7187-7187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7187-7187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -595,10 +596,10 @@
           </code>
           <div class="tip" id="2229">
             <strong>Signature:</strong> unit -&gt; Lonaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7183-7183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7183-7183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -614,10 +615,10 @@
           </code>
           <div class="tip" id="2230">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7183-7183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7183-7183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="2231">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7104-7104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7104-7104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="2232">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7104-7104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7104-7104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="2233">
             <strong>Signature:</strong> unit -&gt; Projection<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7069-7069" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7069-7069" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -694,10 +695,10 @@
           </code>
           <div class="tip" id="2234">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7069-7069" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7069-7069" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -713,10 +714,10 @@
           </code>
           <div class="tip" id="2235">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7060-7060" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7060-7060" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -734,10 +735,10 @@
           </code>
           <div class="tip" id="2236">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7060-7060" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7060-7060" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -755,10 +756,10 @@
           </code>
           <div class="tip" id="2237">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7124-7124" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7124-7124" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -776,10 +777,10 @@
           </code>
           <div class="tip" id="2238">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7124-7124" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7124-7124" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -797,10 +798,10 @@
           </code>
           <div class="tip" id="2239">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7129-7129" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7129-7129" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -818,10 +819,10 @@
           </code>
           <div class="tip" id="2240">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7129-7129" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7129-7129" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -839,10 +840,10 @@
           </code>
           <div class="tip" id="2241">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7065-7065" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7065-7065" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -860,10 +861,10 @@
           </code>
           <div class="tip" id="2242">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7065-7065" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7065-7065" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -881,10 +882,10 @@
           </code>
           <div class="tip" id="2243">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7227-7227" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7227-7227" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -899,10 +900,10 @@
           </code>
           <div class="tip" id="2244">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7224-7224" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7224-7224" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -917,10 +918,10 @@
           </code>
           <div class="tip" id="2245">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7204-7204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7204-7204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -935,10 +936,10 @@
           </code>
           <div class="tip" id="2246">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7205-7205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7205-7205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -953,10 +954,10 @@
           </code>
           <div class="tip" id="2247">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7216-7216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7216-7216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -971,10 +972,10 @@
           </code>
           <div class="tip" id="2248">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7217-7217" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7217-7217" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -989,10 +990,10 @@
           </code>
           <div class="tip" id="2249">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7199-7199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7199-7199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,10 +1008,10 @@
           </code>
           <div class="tip" id="2250">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7222-7222" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7222-7222" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1025,10 +1026,10 @@
           </code>
           <div class="tip" id="2251">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7223-7223" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7223-7223" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1043,10 +1044,10 @@
           </code>
           <div class="tip" id="2252">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7211-7211" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7211-7211" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1061,10 +1062,10 @@
           </code>
           <div class="tip" id="2253">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7207-7207" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7207-7207" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1079,10 +1080,10 @@
           </code>
           <div class="tip" id="2254">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7226-7226" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7226-7226" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1097,10 +1098,10 @@
           </code>
           <div class="tip" id="2255">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7225-7225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7225-7225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1115,10 +1116,10 @@
           </code>
           <div class="tip" id="2256">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7209-7209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7209-7209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1133,10 +1134,10 @@
           </code>
           <div class="tip" id="2257">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7202-7202" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7202-7202" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1151,10 +1152,10 @@
           </code>
           <div class="tip" id="2258">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7200-7200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7200-7200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1169,10 +1170,10 @@
           </code>
           <div class="tip" id="2259">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7213-7213" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7213-7213" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1187,10 +1188,10 @@
           </code>
           <div class="tip" id="2260">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7214-7214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7214-7214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1205,10 +1206,10 @@
           </code>
           <div class="tip" id="2261">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7201-7201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7201-7201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1223,10 +1224,10 @@
           </code>
           <div class="tip" id="2262">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7203-7203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7203-7203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1241,10 +1242,10 @@
           </code>
           <div class="tip" id="2263">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7215-7215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7215-7215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1259,10 +1260,10 @@
           </code>
           <div class="tip" id="2264">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7221-7221" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7221-7221" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1277,10 +1278,10 @@
           </code>
           <div class="tip" id="2265">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7210-7210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7210-7210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1295,10 +1296,10 @@
           </code>
           <div class="tip" id="2266">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7206-7206" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7206-7206" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1313,10 +1314,10 @@
           </code>
           <div class="tip" id="2267">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7208-7208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7208-7208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1331,10 +1332,10 @@
           </code>
           <div class="tip" id="2268">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7212-7212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7212-7212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1349,10 +1350,10 @@
           </code>
           <div class="tip" id="2269">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7218-7218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7218-7218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1367,10 +1368,10 @@
           </code>
           <div class="tip" id="2270">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7219-7219" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7219-7219" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1385,10 +1386,10 @@
           </code>
           <div class="tip" id="2271">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7220-7220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7220-7220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1403,10 +1404,10 @@
           </code>
           <div class="tip" id="2272">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7074-7074" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7074-7074" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1424,10 +1425,10 @@
           </code>
           <div class="tip" id="2273">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7074-7074" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7074-7074" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1445,10 +1446,10 @@
           </code>
           <div class="tip" id="2274">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7134-7134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7134-7134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1466,10 +1467,10 @@
           </code>
           <div class="tip" id="2275">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7134-7134" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7134-7134" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1487,10 +1488,10 @@
           </code>
           <div class="tip" id="2276">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7164-7164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7164-7164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1508,10 +1509,10 @@
           </code>
           <div class="tip" id="2277">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7164-7164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7164-7164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1529,10 +1530,10 @@
           </code>
           <div class="tip" id="2278">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7109-7109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7109-7109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1550,10 +1551,10 @@
           </code>
           <div class="tip" id="2279">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7109-7109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7109-7109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1571,10 +1572,10 @@
           </code>
           <div class="tip" id="2280">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7089-7089" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7089-7089" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1592,10 +1593,10 @@
           </code>
           <div class="tip" id="2281">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7089-7089" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7089-7089" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1613,10 +1614,10 @@
           </code>
           <div class="tip" id="2282">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7099-7099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7099-7099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1634,10 +1635,10 @@
           </code>
           <div class="tip" id="2283">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7099-7099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7099-7099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1655,10 +1656,10 @@
           </code>
           <div class="tip" id="2284">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7119-7119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7119-7119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1676,10 +1677,10 @@
           </code>
           <div class="tip" id="2285">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7119-7119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7119-7119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1697,10 +1698,10 @@
           </code>
           <div class="tip" id="2286">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7149-7149" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7149-7149" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1718,10 +1719,10 @@
           </code>
           <div class="tip" id="2287">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7149-7149" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7149-7149" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1739,10 +1740,10 @@
           </code>
           <div class="tip" id="2288">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7154-7154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7154-7154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1760,10 +1761,10 @@
           </code>
           <div class="tip" id="2289">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7154-7154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7154-7154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1781,10 +1782,10 @@
           </code>
           <div class="tip" id="2290">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7159-7159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7159-7159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1802,10 +1803,10 @@
           </code>
           <div class="tip" id="2291">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7159-7159" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7159-7159" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1827,7 +1828,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1890,6 +1891,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-heatmap.html
+++ b/docs/reference/xplot-plotly-graph-heatmap.html
@@ -5,7 +5,7 @@
     <title>Heatmap - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Heatmap</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2292">
             <strong>Signature:</strong> unit -&gt; Heatmap<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2497-2497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2497-2497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2293">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2655-2655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2655-2655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2294">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2655-2655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2655-2655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2295">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2679-2679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2679-2679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="2296">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2679-2679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2679-2679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="2297">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2650-2650" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2650-2650" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="2298">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2650-2650" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2650-2650" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="2299">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2675-2675" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2675-2675" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="2300">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2675-2675" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2675-2675" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="2301">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2595-2595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2595-2595" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="2302">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2595-2595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2595-2595" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2303">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2610-2610" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2610-2610" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="2304">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2610-2610" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2610-2610" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2305">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2571-2571" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2571-2571" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="2306">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2571-2571" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2571-2571" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="2307">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2552-2552" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2552-2552" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,10 +415,10 @@
           </code>
           <div class="tip" id="2308">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2552-2552" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2552-2552" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="2309">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2557-2557" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2557-2557" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +457,10 @@
           </code>
           <div class="tip" id="2310">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2557-2557" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2557-2557" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="2311">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2660-2660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2660-2660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -498,10 +499,10 @@
           </code>
           <div class="tip" id="2312">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2660-2660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2660-2660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -519,10 +520,10 @@
           </code>
           <div class="tip" id="2313">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2737-2737" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2737-2737" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -537,10 +538,10 @@
           </code>
           <div class="tip" id="2314">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2742-2742" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2742-2742" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -555,10 +556,10 @@
           </code>
           <div class="tip" id="2315">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2736-2736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2736-2736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -573,10 +574,10 @@
           </code>
           <div class="tip" id="2316">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2741-2741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2741-2741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="2317">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2725-2725" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2725-2725" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -609,10 +610,10 @@
           </code>
           <div class="tip" id="2318">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2728-2728" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2728-2728" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -627,10 +628,10 @@
           </code>
           <div class="tip" id="2319">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2720-2720" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2720-2720" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -645,10 +646,10 @@
           </code>
           <div class="tip" id="2320">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2716-2716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2716-2716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -663,10 +664,10 @@
           </code>
           <div class="tip" id="2321">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2717-2717" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2717-2717" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -681,10 +682,10 @@
           </code>
           <div class="tip" id="2322">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2738-2738" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2738-2738" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -699,10 +700,10 @@
           </code>
           <div class="tip" id="2323">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2715-2715" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2715-2715" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="2324">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2739-2739" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2739-2739" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="2325">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2721-2721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2721-2721" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -753,10 +754,10 @@
           </code>
           <div class="tip" id="2326">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2729-2729" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2729-2729" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -771,10 +772,10 @@
           </code>
           <div class="tip" id="2327">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2748-2748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2748-2748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -789,10 +790,10 @@
           </code>
           <div class="tip" id="2328">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2730-2730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2730-2730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -807,10 +808,10 @@
           </code>
           <div class="tip" id="2329">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2713-2713" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2713-2713" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="2330">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2719-2719" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2719-2719" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="2331">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2714-2714" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2714-2714" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="2332">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2723-2723" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2723-2723" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="2333">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2724-2724" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2724-2724" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -897,10 +898,10 @@
           </code>
           <div class="tip" id="2334">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2743-2743" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2743-2743" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -915,10 +916,10 @@
           </code>
           <div class="tip" id="2335">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2746-2746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2746-2746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="2336">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2731-2731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2731-2731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -951,10 +952,10 @@
           </code>
           <div class="tip" id="2337">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2726-2726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2726-2726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="2338">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2727-2727" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2727-2727" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -987,10 +988,10 @@
           </code>
           <div class="tip" id="2339">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2744-2744" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2744-2744" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="2340">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2747-2747" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2747-2747" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1023,10 +1024,10 @@
           </code>
           <div class="tip" id="2341">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2732-2732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2732-2732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1041,10 +1042,10 @@
           </code>
           <div class="tip" id="2342">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2722-2722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2722-2722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1059,10 +1060,10 @@
           </code>
           <div class="tip" id="2343">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2733-2733" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2733-2733" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1077,10 +1078,10 @@
           </code>
           <div class="tip" id="2344">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2735-2735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2735-2735" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1095,10 +1096,10 @@
           </code>
           <div class="tip" id="2345">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2734-2734" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2734-2734" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1113,10 +1114,10 @@
           </code>
           <div class="tip" id="2346">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2740-2740" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2740-2740" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1131,10 +1132,10 @@
           </code>
           <div class="tip" id="2347">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2745-2745" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2745-2745" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1149,10 +1150,10 @@
           </code>
           <div class="tip" id="2348">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2547-2547" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2547-2547" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1170,10 +1171,10 @@
           </code>
           <div class="tip" id="2349">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2547-2547" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2547-2547" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1191,10 +1192,10 @@
           </code>
           <div class="tip" id="2350">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2665-2665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2665-2665" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1212,10 +1213,10 @@
           </code>
           <div class="tip" id="2351">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2665-2665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2665-2665" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1233,10 +1234,10 @@
           </code>
           <div class="tip" id="2352">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2575-2575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2575-2575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1252,10 +1253,10 @@
           </code>
           <div class="tip" id="2353">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2575-2575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2575-2575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1271,10 +1272,10 @@
           </code>
           <div class="tip" id="2354">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2615-2615" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2615-2615" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1292,10 +1293,10 @@
           </code>
           <div class="tip" id="2355">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2615-2615" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2615-2615" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1313,10 +1314,10 @@
           </code>
           <div class="tip" id="2356">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2709-2709" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2709-2709" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1334,10 +1335,10 @@
           </code>
           <div class="tip" id="2357">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2709-2709" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2709-2709" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1355,10 +1356,10 @@
           </code>
           <div class="tip" id="2358">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2620-2620" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2620-2620" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1376,10 +1377,10 @@
           </code>
           <div class="tip" id="2359">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2620-2620" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2620-2620" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1397,10 +1398,10 @@
           </code>
           <div class="tip" id="2360">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2537-2537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2537-2537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1416,10 +1417,10 @@
           </code>
           <div class="tip" id="2361">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2537-2537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2537-2537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1435,10 +1436,10 @@
           </code>
           <div class="tip" id="2362">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2566-2566" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2566-2566" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1456,10 +1457,10 @@
           </code>
           <div class="tip" id="2363">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2566-2566" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2566-2566" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1477,10 +1478,10 @@
           </code>
           <div class="tip" id="2364">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2542-2542" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2542-2542" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1498,10 +1499,10 @@
           </code>
           <div class="tip" id="2365">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2542-2542" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2542-2542" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1519,10 +1520,10 @@
           </code>
           <div class="tip" id="2366">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2585-2585" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2585-2585" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1540,10 +1541,10 @@
           </code>
           <div class="tip" id="2367">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2585-2585" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2585-2585" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1561,10 +1562,10 @@
           </code>
           <div class="tip" id="2368">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2590-2590" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2590-2590" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1582,10 +1583,10 @@
           </code>
           <div class="tip" id="2369">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2590-2590" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2590-2590" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1603,10 +1604,10 @@
           </code>
           <div class="tip" id="2370">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2684-2684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2684-2684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1624,10 +1625,10 @@
           </code>
           <div class="tip" id="2371">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2684-2684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2684-2684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1645,10 +1646,10 @@
           </code>
           <div class="tip" id="2372">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2699-2699" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2699-2699" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1666,10 +1667,10 @@
           </code>
           <div class="tip" id="2373">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2699-2699" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2699-2699" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1687,10 +1688,10 @@
           </code>
           <div class="tip" id="2374">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2625-2625" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2625-2625" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1708,10 +1709,10 @@
           </code>
           <div class="tip" id="2375">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2625-2625" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2625-2625" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1729,10 +1730,10 @@
           </code>
           <div class="tip" id="2376">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2600-2600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2600-2600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1750,10 +1751,10 @@
           </code>
           <div class="tip" id="2377">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2600-2600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2600-2600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1771,10 +1772,10 @@
           </code>
           <div class="tip" id="2378">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2605-2605" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2605-2605" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1792,10 +1793,10 @@
           </code>
           <div class="tip" id="2379">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2605-2605" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2605-2605" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1813,10 +1814,10 @@
           </code>
           <div class="tip" id="2380">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2689-2689" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2689-2689" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1834,10 +1835,10 @@
           </code>
           <div class="tip" id="2381">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2689-2689" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2689-2689" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1855,10 +1856,10 @@
           </code>
           <div class="tip" id="2382">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2704-2704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2704-2704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1876,10 +1877,10 @@
           </code>
           <div class="tip" id="2383">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2704-2704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2704-2704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1897,10 +1898,10 @@
           </code>
           <div class="tip" id="2384">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2630-2630" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2630-2630" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1918,10 +1919,10 @@
           </code>
           <div class="tip" id="2385">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2630-2630" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2630-2630" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1939,10 +1940,10 @@
           </code>
           <div class="tip" id="2386">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2580-2580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2580-2580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1960,10 +1961,10 @@
           </code>
           <div class="tip" id="2387">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2580-2580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2580-2580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1981,10 +1982,10 @@
           </code>
           <div class="tip" id="2388">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2635-2635" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2635-2635" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2002,10 +2003,10 @@
           </code>
           <div class="tip" id="2389">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2635-2635" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2635-2635" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2023,10 +2024,10 @@
           </code>
           <div class="tip" id="2390">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2645-2645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2645-2645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2044,10 +2045,10 @@
           </code>
           <div class="tip" id="2391">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2645-2645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2645-2645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2065,10 +2066,10 @@
           </code>
           <div class="tip" id="2392">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2640-2640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2640-2640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2086,10 +2087,10 @@
           </code>
           <div class="tip" id="2393">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2640-2640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2640-2640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2107,10 +2108,10 @@
           </code>
           <div class="tip" id="2394">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2670-2670" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2670-2670" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2128,10 +2129,10 @@
           </code>
           <div class="tip" id="2395">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2670-2670" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2670-2670" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2149,10 +2150,10 @@
           </code>
           <div class="tip" id="2396">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2694-2694" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2694-2694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2170,10 +2171,10 @@
           </code>
           <div class="tip" id="2397">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2694-2694" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2694-2694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2195,7 +2196,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2258,6 +2259,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-histogram.html
+++ b/docs/reference/xplot-plotly-graph-histogram.html
@@ -5,7 +5,7 @@
     <title>Histogram - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Histogram</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2398">
             <strong>Signature:</strong> unit -&gt; Histogram<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2750-2750" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2750-2750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2399">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2905-2905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2905-2905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2400">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2905-2905" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2905-2905" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2401">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2919-2919" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2919-2919" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2402">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2919-2919" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2919-2919" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2403">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2846-2846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2846-2846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2404">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2846-2846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2846-2846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2405">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2861-2861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2861-2861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2406">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2861-2861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2861-2861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2407">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2936-2936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2936-2936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -290,10 +291,10 @@
           </code>
           <div class="tip" id="2408">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2936-2936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2936-2936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2409">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2932-2932" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2932-2932" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -328,10 +329,10 @@
           </code>
           <div class="tip" id="2410">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2932-2932" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2932-2932" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="2411">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2895-2895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2895-2895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="2412">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2895-2895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2895-2895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="2413">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2900-2900" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2900-2900" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="2414">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2900-2900" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2900-2900" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="2415">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2827-2827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2827-2827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="2416">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2827-2827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2827-2827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="2417">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2808-2808" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2808-2808" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="2418">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2808-2808" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2808-2808" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2419">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2875-2875" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2875-2875" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -534,10 +535,10 @@
           </code>
           <div class="tip" id="2420">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2875-2875" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2875-2875" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="2421">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2910-2910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2910-2910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -574,10 +575,10 @@
           </code>
           <div class="tip" id="2422">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2910-2910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2910-2910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -595,10 +596,10 @@
           </code>
           <div class="tip" id="2423">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2924-2924" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2924-2924" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -616,10 +617,10 @@
           </code>
           <div class="tip" id="2424">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2924-2924" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2924-2924" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -637,10 +638,10 @@
           </code>
           <div class="tip" id="2425">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2813-2813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2813-2813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -658,10 +659,10 @@
           </code>
           <div class="tip" id="2426">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2813-2813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2813-2813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,10 +680,10 @@
           </code>
           <div class="tip" id="2427">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2871-2871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2871-2871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -700,10 +701,10 @@
           </code>
           <div class="tip" id="2428">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2871-2871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2871-2871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -721,10 +722,10 @@
           </code>
           <div class="tip" id="2429">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2880-2880" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2880-2880" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -742,10 +743,10 @@
           </code>
           <div class="tip" id="2430">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2880-2880" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2880-2880" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -763,10 +764,10 @@
           </code>
           <div class="tip" id="2431">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2966-2966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2966-2966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -784,10 +785,10 @@
           </code>
           <div class="tip" id="2432">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2966-2966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2966-2966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -805,10 +806,10 @@
           </code>
           <div class="tip" id="2433">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3003-3003" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3003-3003" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -823,10 +824,10 @@
           </code>
           <div class="tip" id="2434">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3006-3006" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3006-3006" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -841,10 +842,10 @@
           </code>
           <div class="tip" id="2435">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2991-2991" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2991-2991" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -859,10 +860,10 @@
           </code>
           <div class="tip" id="2436">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2994-2994" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2994-2994" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -877,10 +878,10 @@
           </code>
           <div class="tip" id="2437">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3010-3010" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3010-3010" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -895,10 +896,10 @@
           </code>
           <div class="tip" id="2438">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3009-3009" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3009-3009" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -913,10 +914,10 @@
           </code>
           <div class="tip" id="2439">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3001-3001" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3001-3001" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -931,10 +932,10 @@
           </code>
           <div class="tip" id="2440">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3002-3002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3002-3002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -949,10 +950,10 @@
           </code>
           <div class="tip" id="2441">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2987-2987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2987-2987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -967,10 +968,10 @@
           </code>
           <div class="tip" id="2442">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2983-2983" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2983-2983" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -985,10 +986,10 @@
           </code>
           <div class="tip" id="2443">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2997-2997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2997-2997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1003,10 +1004,10 @@
           </code>
           <div class="tip" id="2444">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3004-3004" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3004-3004" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1021,10 +1022,10 @@
           </code>
           <div class="tip" id="2445">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3007-3007" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3007-3007" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1039,10 +1040,10 @@
           </code>
           <div class="tip" id="2446">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2984-2984" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2984-2984" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1057,10 +1058,10 @@
           </code>
           <div class="tip" id="2447">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2996-2996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2996-2996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1075,10 +1076,10 @@
           </code>
           <div class="tip" id="2448">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2998-2998" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2998-2998" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1093,10 +1094,10 @@
           </code>
           <div class="tip" id="2449">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3016-3016" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3016-3016" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1111,10 +1112,10 @@
           </code>
           <div class="tip" id="2450">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2982-2982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2982-2982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1129,10 +1130,10 @@
           </code>
           <div class="tip" id="2451">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2988-2988" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2988-2988" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1147,10 +1148,10 @@
           </code>
           <div class="tip" id="2452">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2999-2999" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2999-2999" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1165,10 +1166,10 @@
           </code>
           <div class="tip" id="2453">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2995-2995" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2995-2995" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1183,10 +1184,10 @@
           </code>
           <div class="tip" id="2454">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3015-3015" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3015-3015" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1201,10 +1202,10 @@
           </code>
           <div class="tip" id="2455">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3017-3017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3017-3017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1219,10 +1220,10 @@
           </code>
           <div class="tip" id="2456">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2980-2980" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2980-2980" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1237,10 +1238,10 @@
           </code>
           <div class="tip" id="2457">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2986-2986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2986-2986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1255,10 +1256,10 @@
           </code>
           <div class="tip" id="2458">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2981-2981" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2981-2981" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1273,10 +1274,10 @@
           </code>
           <div class="tip" id="2459">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2989-2989" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2989-2989" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1291,10 +1292,10 @@
           </code>
           <div class="tip" id="2460">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2990-2990" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2990-2990" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1309,10 +1310,10 @@
           </code>
           <div class="tip" id="2461">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3011-3011" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3011-3011" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1327,10 +1328,10 @@
           </code>
           <div class="tip" id="2462">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3005-3005" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3005-3005" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1345,10 +1346,10 @@
           </code>
           <div class="tip" id="2463">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3013-3013" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3013-3013" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1363,10 +1364,10 @@
           </code>
           <div class="tip" id="2464">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2992-2992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2992-2992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1381,10 +1382,10 @@
           </code>
           <div class="tip" id="2465">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2993-2993" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2993-2993" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1399,10 +1400,10 @@
           </code>
           <div class="tip" id="2466">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3012-3012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3012-3012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1417,10 +1418,10 @@
           </code>
           <div class="tip" id="2467">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3008-3008" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3008-3008" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1435,10 +1436,10 @@
           </code>
           <div class="tip" id="2468">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3014-3014" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3014-3014" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1453,10 +1454,10 @@
           </code>
           <div class="tip" id="2469">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3000-3000" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3000-3000" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1471,10 +1472,10 @@
           </code>
           <div class="tip" id="2470">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3018-3018" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3018-3018" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1489,10 +1490,10 @@
           </code>
           <div class="tip" id="2471">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2803-2803" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2803-2803" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1510,10 +1511,10 @@
           </code>
           <div class="tip" id="2472">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2803-2803" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2803-2803" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1531,10 +1532,10 @@
           </code>
           <div class="tip" id="2473">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2831-2831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2831-2831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1550,10 +1551,10 @@
           </code>
           <div class="tip" id="2474">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2831-2831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2831-2831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1569,10 +1570,10 @@
           </code>
           <div class="tip" id="2475">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2885-2885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2885-2885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1590,10 +1591,10 @@
           </code>
           <div class="tip" id="2476">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2885-2885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2885-2885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1611,10 +1612,10 @@
           </code>
           <div class="tip" id="2477">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2866-2866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2866-2866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1632,10 +1633,10 @@
           </code>
           <div class="tip" id="2478">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2866-2866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2866-2866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1653,10 +1654,10 @@
           </code>
           <div class="tip" id="2479">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2961-2961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2961-2961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1674,10 +1675,10 @@
           </code>
           <div class="tip" id="2480">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2961-2961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2961-2961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1695,10 +1696,10 @@
           </code>
           <div class="tip" id="2481">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2971-2971" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2971-2971" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1716,10 +1717,10 @@
           </code>
           <div class="tip" id="2482">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2971-2971" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2971-2971" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1737,10 +1738,10 @@
           </code>
           <div class="tip" id="2483">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2793-2793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2793-2793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1756,10 +1757,10 @@
           </code>
           <div class="tip" id="2484">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2793-2793" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2793-2793" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1775,10 +1776,10 @@
           </code>
           <div class="tip" id="2485">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2822-2822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2822-2822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1796,10 +1797,10 @@
           </code>
           <div class="tip" id="2486">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2822-2822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2822-2822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1817,10 +1818,10 @@
           </code>
           <div class="tip" id="2487">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2798-2798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2798-2798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1838,10 +1839,10 @@
           </code>
           <div class="tip" id="2488">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2798-2798" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2798-2798" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1859,10 +1860,10 @@
           </code>
           <div class="tip" id="2489">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2836-2836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2836-2836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1880,10 +1881,10 @@
           </code>
           <div class="tip" id="2490">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2836-2836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2836-2836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1901,10 +1902,10 @@
           </code>
           <div class="tip" id="2491">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2841-2841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2841-2841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1922,10 +1923,10 @@
           </code>
           <div class="tip" id="2492">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2841-2841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2841-2841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1943,10 +1944,10 @@
           </code>
           <div class="tip" id="2493">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2941-2941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2941-2941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1964,10 +1965,10 @@
           </code>
           <div class="tip" id="2494">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2941-2941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2941-2941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1985,10 +1986,10 @@
           </code>
           <div class="tip" id="2495">
             <strong>Signature:</strong> unit -&gt; Xbins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2914-2914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2914-2914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2004,10 +2005,10 @@
           </code>
           <div class="tip" id="2496">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2914-2914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2914-2914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2023,10 +2024,10 @@
           </code>
           <div class="tip" id="2497">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2951-2951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2951-2951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2044,10 +2045,10 @@
           </code>
           <div class="tip" id="2498">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2951-2951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2951-2951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2065,10 +2066,10 @@
           </code>
           <div class="tip" id="2499">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2851-2851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2851-2851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2086,10 +2087,10 @@
           </code>
           <div class="tip" id="2500">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2851-2851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2851-2851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2107,10 +2108,10 @@
           </code>
           <div class="tip" id="2501">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2856-2856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2856-2856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2128,10 +2129,10 @@
           </code>
           <div class="tip" id="2502">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2856-2856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2856-2856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2149,10 +2150,10 @@
           </code>
           <div class="tip" id="2503">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2946-2946" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2946-2946" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2170,10 +2171,10 @@
           </code>
           <div class="tip" id="2504">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2946-2946" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2946-2946" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2191,10 +2192,10 @@
           </code>
           <div class="tip" id="2505">
             <strong>Signature:</strong> unit -&gt; Ybins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2928-2928" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2928-2928" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2210,10 +2211,10 @@
           </code>
           <div class="tip" id="2506">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2928-2928" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2928-2928" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2229,10 +2230,10 @@
           </code>
           <div class="tip" id="2507">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2956-2956" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2956-2956" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2250,10 +2251,10 @@
           </code>
           <div class="tip" id="2508">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2956-2956" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2956-2956" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2271,10 +2272,10 @@
           </code>
           <div class="tip" id="2509">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2890-2890" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2890-2890" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2292,10 +2293,10 @@
           </code>
           <div class="tip" id="2510">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2890-2890" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2890-2890" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2313,10 +2314,10 @@
           </code>
           <div class="tip" id="2511">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2976-2976" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2976-2976" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2334,10 +2335,10 @@
           </code>
           <div class="tip" id="2512">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2976-2976" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L2976-2976" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2359,7 +2360,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2422,6 +2423,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-histogram2d.html
+++ b/docs/reference/xplot-plotly-graph-histogram2d.html
@@ -5,7 +5,7 @@
     <title>Histogram2d - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Histogram2d</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2513">
             <strong>Signature:</strong> unit -&gt; Histogram2d<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3022-3022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3022-3022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2514">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3238-3238" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3238-3238" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2515">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3238-3238" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3238-3238" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2516">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3252-3252" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3252-3252" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2517">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3252-3252" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3252-3252" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2518">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3190-3190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3190-3190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2519">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3190-3190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3190-3190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2520">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3214-3214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3214-3214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -248,10 +249,10 @@
           </code>
           <div class="tip" id="2521">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3214-3214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3214-3214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="2522">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3185-3185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3185-3185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="2523">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3185-3185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3185-3185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2524">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3210-3210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3210-3210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="2525">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3210-3210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3210-3210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2526">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3130-3130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3130-3130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="2527">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3130-3130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3130-3130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="2528">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3145-3145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3145-3145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,10 +415,10 @@
           </code>
           <div class="tip" id="2529">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3145-3145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3145-3145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="2530">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3228-3228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3228-3228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +457,10 @@
           </code>
           <div class="tip" id="2531">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3228-3228" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3228-3228" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="2532">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3233-3233" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3233-3233" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -498,10 +499,10 @@
           </code>
           <div class="tip" id="2533">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3233-3233" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3233-3233" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -519,10 +520,10 @@
           </code>
           <div class="tip" id="2534">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3106-3106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3106-3106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -540,10 +541,10 @@
           </code>
           <div class="tip" id="2535">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3106-3106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3106-3106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -561,10 +562,10 @@
           </code>
           <div class="tip" id="2536">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3087-3087" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3087-3087" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -582,10 +583,10 @@
           </code>
           <div class="tip" id="2537">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3087-3087" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3087-3087" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -603,10 +604,10 @@
           </code>
           <div class="tip" id="2538">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3218-3218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3218-3218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -622,10 +623,10 @@
           </code>
           <div class="tip" id="2539">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3218-3218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3218-3218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2540">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3243-3243" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3243-3243" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="2541">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3243-3243" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3243-3243" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="2542">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3257-3257" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3257-3257" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -704,10 +705,10 @@
           </code>
           <div class="tip" id="2543">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3257-3257" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3257-3257" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="2544">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3092-3092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3092-3092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -746,10 +747,10 @@
           </code>
           <div class="tip" id="2545">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3092-3092" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3092-3092" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -767,10 +768,10 @@
           </code>
           <div class="tip" id="2546">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3223-3223" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3223-3223" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -788,10 +789,10 @@
           </code>
           <div class="tip" id="2547">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3223-3223" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3223-3223" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -809,10 +810,10 @@
           </code>
           <div class="tip" id="2548">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3195-3195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3195-3195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -830,10 +831,10 @@
           </code>
           <div class="tip" id="2549">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3195-3195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3195-3195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -851,10 +852,10 @@
           </code>
           <div class="tip" id="2550">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3329-3329" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3329-3329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -869,10 +870,10 @@
           </code>
           <div class="tip" id="2551">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3332-3332" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3332-3332" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -887,10 +888,10 @@
           </code>
           <div class="tip" id="2552">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3319-3319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3319-3319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -905,10 +906,10 @@
           </code>
           <div class="tip" id="2553">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3324-3324" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3324-3324" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -923,10 +924,10 @@
           </code>
           <div class="tip" id="2554">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3318-3318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3318-3318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -941,10 +942,10 @@
           </code>
           <div class="tip" id="2555">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3323-3323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3323-3323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -959,10 +960,10 @@
           </code>
           <div class="tip" id="2556">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3307-3307" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3307-3307" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -977,10 +978,10 @@
           </code>
           <div class="tip" id="2557">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3310-3310" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3310-3310" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -995,10 +996,10 @@
           </code>
           <div class="tip" id="2558">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3327-3327" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3327-3327" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1013,10 +1014,10 @@
           </code>
           <div class="tip" id="2559">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3328-3328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3328-3328" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1031,10 +1032,10 @@
           </code>
           <div class="tip" id="2560">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3302-3302" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3302-3302" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1049,10 +1050,10 @@
           </code>
           <div class="tip" id="2561">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3298-3298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3298-3298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1067,10 +1068,10 @@
           </code>
           <div class="tip" id="2562">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3325-3325" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3325-3325" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1085,10 +1086,10 @@
           </code>
           <div class="tip" id="2563">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3330-3330" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3330-3330" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1103,10 +1104,10 @@
           </code>
           <div class="tip" id="2564">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3333-3333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3333-3333" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1121,10 +1122,10 @@
           </code>
           <div class="tip" id="2565">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3299-3299" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3299-3299" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1139,10 +1140,10 @@
           </code>
           <div class="tip" id="2566">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3326-3326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3326-3326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1157,10 +1158,10 @@
           </code>
           <div class="tip" id="2567">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3320-3320" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3320-3320" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1175,10 +1176,10 @@
           </code>
           <div class="tip" id="2568">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3297-3297" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3297-3297" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1193,10 +1194,10 @@
           </code>
           <div class="tip" id="2569">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3321-3321" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3321-3321" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1211,10 +1212,10 @@
           </code>
           <div class="tip" id="2570">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3303-3303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3303-3303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1229,10 +1230,10 @@
           </code>
           <div class="tip" id="2571">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3311-3311" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3311-3311" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1247,10 +1248,10 @@
           </code>
           <div class="tip" id="2572">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3340-3340" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3340-3340" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1265,10 +1266,10 @@
           </code>
           <div class="tip" id="2573">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3312-3312" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3312-3312" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1283,10 +1284,10 @@
           </code>
           <div class="tip" id="2574">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3295-3295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3295-3295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1301,10 +1302,10 @@
           </code>
           <div class="tip" id="2575">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3301-3301" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3301-3301" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1319,10 +1320,10 @@
           </code>
           <div class="tip" id="2576">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3296-3296" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3296-3296" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1337,10 +1338,10 @@
           </code>
           <div class="tip" id="2577">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3305-3305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3305-3305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1355,10 +1356,10 @@
           </code>
           <div class="tip" id="2578">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3306-3306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3306-3306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1373,10 +1374,10 @@
           </code>
           <div class="tip" id="2579">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3335-3335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3335-3335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1391,10 +1392,10 @@
           </code>
           <div class="tip" id="2580">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3331-3331" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3331-3331" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1409,10 +1410,10 @@
           </code>
           <div class="tip" id="2581">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3338-3338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3338-3338" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1427,10 +1428,10 @@
           </code>
           <div class="tip" id="2582">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3313-3313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3313-3313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1445,10 +1446,10 @@
           </code>
           <div class="tip" id="2583">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3308-3308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3308-3308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1463,10 +1464,10 @@
           </code>
           <div class="tip" id="2584">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3309-3309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3309-3309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1481,10 +1482,10 @@
           </code>
           <div class="tip" id="2585">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3336-3336" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3336-3336" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1499,10 +1500,10 @@
           </code>
           <div class="tip" id="2586">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3334-3334" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3334-3334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1517,10 +1518,10 @@
           </code>
           <div class="tip" id="2587">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3339-3339" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3339-3339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1535,10 +1536,10 @@
           </code>
           <div class="tip" id="2588">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3314-3314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3314-3314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1553,10 +1554,10 @@
           </code>
           <div class="tip" id="2589">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3304-3304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3304-3304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1571,10 +1572,10 @@
           </code>
           <div class="tip" id="2590">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3315-3315" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3315-3315" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1589,10 +1590,10 @@
           </code>
           <div class="tip" id="2591">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3317-3317" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3317-3317" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1607,10 +1608,10 @@
           </code>
           <div class="tip" id="2592">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3316-3316" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3316-3316" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1625,10 +1626,10 @@
           </code>
           <div class="tip" id="2593">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3322-3322" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3322-3322" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1643,10 +1644,10 @@
           </code>
           <div class="tip" id="2594">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3337-3337" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3337-3337" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1661,10 +1662,10 @@
           </code>
           <div class="tip" id="2595">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3082-3082" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3082-3082" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1682,10 +1683,10 @@
           </code>
           <div class="tip" id="2596">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3082-3082" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3082-3082" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1703,10 +1704,10 @@
           </code>
           <div class="tip" id="2597">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3200-3200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3200-3200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1724,10 +1725,10 @@
           </code>
           <div class="tip" id="2598">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3200-3200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3200-3200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1745,10 +1746,10 @@
           </code>
           <div class="tip" id="2599">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3110-3110" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3110-3110" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1764,10 +1765,10 @@
           </code>
           <div class="tip" id="2600">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3110-3110" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3110-3110" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1783,10 +1784,10 @@
           </code>
           <div class="tip" id="2601">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3150-3150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3150-3150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1804,10 +1805,10 @@
           </code>
           <div class="tip" id="2602">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3150-3150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3150-3150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1825,10 +1826,10 @@
           </code>
           <div class="tip" id="2603">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3291-3291" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3291-3291" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1846,10 +1847,10 @@
           </code>
           <div class="tip" id="2604">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3291-3291" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3291-3291" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1867,10 +1868,10 @@
           </code>
           <div class="tip" id="2605">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3155-3155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3155-3155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1888,10 +1889,10 @@
           </code>
           <div class="tip" id="2606">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3155-3155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3155-3155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1909,10 +1910,10 @@
           </code>
           <div class="tip" id="2607">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3072-3072" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3072-3072" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1928,10 +1929,10 @@
           </code>
           <div class="tip" id="2608">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3072-3072" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3072-3072" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1947,10 +1948,10 @@
           </code>
           <div class="tip" id="2609">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3101-3101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3101-3101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1968,10 +1969,10 @@
           </code>
           <div class="tip" id="2610">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3101-3101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3101-3101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1989,10 +1990,10 @@
           </code>
           <div class="tip" id="2611">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3077-3077" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3077-3077" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2010,10 +2011,10 @@
           </code>
           <div class="tip" id="2612">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3077-3077" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3077-3077" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2031,10 +2032,10 @@
           </code>
           <div class="tip" id="2613">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3120-3120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3120-3120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2052,10 +2053,10 @@
           </code>
           <div class="tip" id="2614">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3120-3120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3120-3120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2073,10 +2074,10 @@
           </code>
           <div class="tip" id="2615">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3125-3125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3125-3125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2094,10 +2095,10 @@
           </code>
           <div class="tip" id="2616">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3125-3125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3125-3125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2115,10 +2116,10 @@
           </code>
           <div class="tip" id="2617">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3266-3266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3266-3266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2136,10 +2137,10 @@
           </code>
           <div class="tip" id="2618">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3266-3266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3266-3266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2157,10 +2158,10 @@
           </code>
           <div class="tip" id="2619">
             <strong>Signature:</strong> unit -&gt; Xbins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3247-3247" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3247-3247" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2176,10 +2177,10 @@
           </code>
           <div class="tip" id="2620">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3247-3247" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3247-3247" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2195,10 +2196,10 @@
           </code>
           <div class="tip" id="2621">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3281-3281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3281-3281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2216,10 +2217,10 @@
           </code>
           <div class="tip" id="2622">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3281-3281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3281-3281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2237,10 +2238,10 @@
           </code>
           <div class="tip" id="2623">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3160-3160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3160-3160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2258,10 +2259,10 @@
           </code>
           <div class="tip" id="2624">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3160-3160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3160-3160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2279,10 +2280,10 @@
           </code>
           <div class="tip" id="2625">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3135-3135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3135-3135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2300,10 +2301,10 @@
           </code>
           <div class="tip" id="2626">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3135-3135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3135-3135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2321,10 +2322,10 @@
           </code>
           <div class="tip" id="2627">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3140-3140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3140-3140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2342,10 +2343,10 @@
           </code>
           <div class="tip" id="2628">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3140-3140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3140-3140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2363,10 +2364,10 @@
           </code>
           <div class="tip" id="2629">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3271-3271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3271-3271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2384,10 +2385,10 @@
           </code>
           <div class="tip" id="2630">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3271-3271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3271-3271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2405,10 +2406,10 @@
           </code>
           <div class="tip" id="2631">
             <strong>Signature:</strong> unit -&gt; Ybins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3261-3261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3261-3261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2424,10 +2425,10 @@
           </code>
           <div class="tip" id="2632">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3261-3261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3261-3261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2443,10 +2444,10 @@
           </code>
           <div class="tip" id="2633">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3286-3286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3286-3286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2464,10 +2465,10 @@
           </code>
           <div class="tip" id="2634">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3286-3286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3286-3286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2485,10 +2486,10 @@
           </code>
           <div class="tip" id="2635">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3165-3165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3165-3165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2506,10 +2507,10 @@
           </code>
           <div class="tip" id="2636">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3165-3165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3165-3165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2527,10 +2528,10 @@
           </code>
           <div class="tip" id="2637">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3115-3115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3115-3115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2548,10 +2549,10 @@
           </code>
           <div class="tip" id="2638">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3115-3115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3115-3115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2569,10 +2570,10 @@
           </code>
           <div class="tip" id="2639">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3170-3170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3170-3170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2590,10 +2591,10 @@
           </code>
           <div class="tip" id="2640">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3170-3170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3170-3170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2611,10 +2612,10 @@
           </code>
           <div class="tip" id="2641">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3180-3180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3180-3180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2632,10 +2633,10 @@
           </code>
           <div class="tip" id="2642">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3180-3180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3180-3180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2653,10 +2654,10 @@
           </code>
           <div class="tip" id="2643">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3175-3175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3175-3175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2674,10 +2675,10 @@
           </code>
           <div class="tip" id="2644">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3175-3175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3175-3175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2695,10 +2696,10 @@
           </code>
           <div class="tip" id="2645">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3205-3205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3205-3205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2716,10 +2717,10 @@
           </code>
           <div class="tip" id="2646">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3205-3205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3205-3205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2737,10 +2738,10 @@
           </code>
           <div class="tip" id="2647">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3276-3276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3276-3276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2758,10 +2759,10 @@
           </code>
           <div class="tip" id="2648">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3276-3276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3276-3276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2783,7 +2784,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2846,6 +2847,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-histogram2dcontour.html
+++ b/docs/reference/xplot-plotly-graph-histogram2dcontour.html
@@ -5,7 +5,7 @@
     <title>Histogram2dcontour - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Histogram2dcontour</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2649">
             <strong>Signature:</strong> unit -&gt; Histogram2dcontour<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3870-3870" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3870-3870" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2650">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4090-4090" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4090-4090" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2651">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4090-4090" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4090-4090" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2652">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4104-4104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4104-4104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2653">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4104-4104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4104-4104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2654">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4042-4042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4042-4042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2655">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4042-4042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4042-4042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2656">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4118-4118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4118-4118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2657">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4118-4118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4118-4118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2658">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4066-4066" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4066-4066" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -290,10 +291,10 @@
           </code>
           <div class="tip" id="2659">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4066-4066" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4066-4066" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2660">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4037-4037" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4037-4037" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -330,10 +331,10 @@
           </code>
           <div class="tip" id="2661">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4037-4037" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4037-4037" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2662">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4062-4062" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4062-4062" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="2663">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4062-4062" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4062-4062" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="2664">
             <strong>Signature:</strong> unit -&gt; Contours<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4127-4127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4127-4127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -412,10 +413,10 @@
           </code>
           <div class="tip" id="2665">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4127-4127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4127-4127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="2666">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3982-3982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3982-3982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="2667">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3982-3982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3982-3982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="2668">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3997-3997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3997-3997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="2669">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3997-3997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3997-3997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="2670">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4080-4080" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4080-4080" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="2671">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4080-4080" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4080-4080" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="2672">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4085-4085" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4085-4085" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="2673">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4085-4085" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4085-4085" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="2674">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3958-3958" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3958-3958" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -620,10 +621,10 @@
           </code>
           <div class="tip" id="2675">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3958-3958" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3958-3958" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2676">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3939-3939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3939-3939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="2677">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3939-3939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3939-3939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="2678">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4131-4131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4131-4131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -702,10 +703,10 @@
           </code>
           <div class="tip" id="2679">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4131-4131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4131-4131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -721,10 +722,10 @@
           </code>
           <div class="tip" id="2680">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4070-4070" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4070-4070" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -740,10 +741,10 @@
           </code>
           <div class="tip" id="2681">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4070-4070" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4070-4070" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -759,10 +760,10 @@
           </code>
           <div class="tip" id="2682">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4095-4095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4095-4095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -780,10 +781,10 @@
           </code>
           <div class="tip" id="2683">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4095-4095" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4095-4095" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -801,10 +802,10 @@
           </code>
           <div class="tip" id="2684">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4109-4109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4109-4109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -822,10 +823,10 @@
           </code>
           <div class="tip" id="2685">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4109-4109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4109-4109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="2686">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4123-4123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4123-4123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -864,10 +865,10 @@
           </code>
           <div class="tip" id="2687">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4123-4123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4123-4123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -885,10 +886,10 @@
           </code>
           <div class="tip" id="2688">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3944-3944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3944-3944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -906,10 +907,10 @@
           </code>
           <div class="tip" id="2689">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3944-3944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3944-3944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -927,10 +928,10 @@
           </code>
           <div class="tip" id="2690">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4075-4075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4075-4075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -948,10 +949,10 @@
           </code>
           <div class="tip" id="2691">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4075-4075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4075-4075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="2692">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4047-4047" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4047-4047" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -990,10 +991,10 @@
           </code>
           <div class="tip" id="2693">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4047-4047" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4047-4047" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1011,10 +1012,10 @@
           </code>
           <div class="tip" id="2694">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4199-4199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4199-4199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1029,10 +1030,10 @@
           </code>
           <div class="tip" id="2695">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4202-4202" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4202-4202" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1047,10 +1048,10 @@
           </code>
           <div class="tip" id="2696">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4189-4189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4189-4189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1065,10 +1066,10 @@
           </code>
           <div class="tip" id="2697">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4205-4205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4205-4205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1083,10 +1084,10 @@
           </code>
           <div class="tip" id="2698">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4194-4194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4194-4194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1101,10 +1102,10 @@
           </code>
           <div class="tip" id="2699">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4188-4188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4188-4188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1119,10 +1120,10 @@
           </code>
           <div class="tip" id="2700">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4193-4193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4193-4193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1137,10 +1138,10 @@
           </code>
           <div class="tip" id="2701">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4207-4207" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4207-4207" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1155,10 +1156,10 @@
           </code>
           <div class="tip" id="2702">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4177-4177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4177-4177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1173,10 +1174,10 @@
           </code>
           <div class="tip" id="2703">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4180-4180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4180-4180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1191,10 +1192,10 @@
           </code>
           <div class="tip" id="2704">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4197-4197" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4197-4197" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1209,10 +1210,10 @@
           </code>
           <div class="tip" id="2705">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4198-4198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4198-4198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1227,10 +1228,10 @@
           </code>
           <div class="tip" id="2706">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4172-4172" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4172-4172" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1245,10 +1246,10 @@
           </code>
           <div class="tip" id="2707">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4168-4168" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4168-4168" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1263,10 +1264,10 @@
           </code>
           <div class="tip" id="2708">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4208-4208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4208-4208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1281,10 +1282,10 @@
           </code>
           <div class="tip" id="2709">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4195-4195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4195-4195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1299,10 +1300,10 @@
           </code>
           <div class="tip" id="2710">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4200-4200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4200-4200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1317,10 +1318,10 @@
           </code>
           <div class="tip" id="2711">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4203-4203" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4203-4203" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1335,10 +1336,10 @@
           </code>
           <div class="tip" id="2712">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4206-4206" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4206-4206" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1353,10 +1354,10 @@
           </code>
           <div class="tip" id="2713">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4169-4169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4169-4169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1371,10 +1372,10 @@
           </code>
           <div class="tip" id="2714">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4196-4196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4196-4196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1389,10 +1390,10 @@
           </code>
           <div class="tip" id="2715">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4190-4190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4190-4190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1407,10 +1408,10 @@
           </code>
           <div class="tip" id="2716">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4167-4167" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4167-4167" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1425,10 +1426,10 @@
           </code>
           <div class="tip" id="2717">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4191-4191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4191-4191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1443,10 +1444,10 @@
           </code>
           <div class="tip" id="2718">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4173-4173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4173-4173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1461,10 +1462,10 @@
           </code>
           <div class="tip" id="2719">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4181-4181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4181-4181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1479,10 +1480,10 @@
           </code>
           <div class="tip" id="2720">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4214-4214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4214-4214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1497,10 +1498,10 @@
           </code>
           <div class="tip" id="2721">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4182-4182" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4182-4182" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1515,10 +1516,10 @@
           </code>
           <div class="tip" id="2722">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4165-4165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4165-4165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1533,10 +1534,10 @@
           </code>
           <div class="tip" id="2723">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4171-4171" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4171-4171" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1551,10 +1552,10 @@
           </code>
           <div class="tip" id="2724">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4166-4166" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4166-4166" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1569,10 +1570,10 @@
           </code>
           <div class="tip" id="2725">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4175-4175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4175-4175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1587,10 +1588,10 @@
           </code>
           <div class="tip" id="2726">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4176-4176" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4176-4176" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1605,10 +1606,10 @@
           </code>
           <div class="tip" id="2727">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4209-4209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4209-4209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1623,10 +1624,10 @@
           </code>
           <div class="tip" id="2728">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4201-4201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4201-4201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1641,10 +1642,10 @@
           </code>
           <div class="tip" id="2729">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4212-4212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4212-4212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1659,10 +1660,10 @@
           </code>
           <div class="tip" id="2730">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4183-4183" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4183-4183" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1677,10 +1678,10 @@
           </code>
           <div class="tip" id="2731">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4178-4178" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4178-4178" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1695,10 +1696,10 @@
           </code>
           <div class="tip" id="2732">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4179-4179" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4179-4179" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1713,10 +1714,10 @@
           </code>
           <div class="tip" id="2733">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4210-4210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4210-4210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1731,10 +1732,10 @@
           </code>
           <div class="tip" id="2734">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4204-4204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4204-4204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1749,10 +1750,10 @@
           </code>
           <div class="tip" id="2735">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4213-4213" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4213-4213" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1767,10 +1768,10 @@
           </code>
           <div class="tip" id="2736">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4184-4184" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4184-4184" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1785,10 +1786,10 @@
           </code>
           <div class="tip" id="2737">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4174-4174" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4174-4174" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1803,10 +1804,10 @@
           </code>
           <div class="tip" id="2738">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4185-4185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4185-4185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1821,10 +1822,10 @@
           </code>
           <div class="tip" id="2739">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4187-4187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4187-4187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1839,10 +1840,10 @@
           </code>
           <div class="tip" id="2740">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4186-4186" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4186-4186" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1857,10 +1858,10 @@
           </code>
           <div class="tip" id="2741">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4192-4192" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4192-4192" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1875,10 +1876,10 @@
           </code>
           <div class="tip" id="2742">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4211-4211" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4211-4211" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1893,10 +1894,10 @@
           </code>
           <div class="tip" id="2743">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3934-3934" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3934-3934" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1914,10 +1915,10 @@
           </code>
           <div class="tip" id="2744">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3934-3934" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3934-3934" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1935,10 +1936,10 @@
           </code>
           <div class="tip" id="2745">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4052-4052" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4052-4052" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1956,10 +1957,10 @@
           </code>
           <div class="tip" id="2746">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4052-4052" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4052-4052" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1977,10 +1978,10 @@
           </code>
           <div class="tip" id="2747">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3962-3962" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3962-3962" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1996,10 +1997,10 @@
           </code>
           <div class="tip" id="2748">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3962-3962" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3962-3962" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2015,10 +2016,10 @@
           </code>
           <div class="tip" id="2749">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4002-4002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4002-4002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2036,10 +2037,10 @@
           </code>
           <div class="tip" id="2750">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4002-4002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4002-4002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2057,10 +2058,10 @@
           </code>
           <div class="tip" id="2751">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4161-4161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4161-4161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2078,10 +2079,10 @@
           </code>
           <div class="tip" id="2752">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4161-4161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4161-4161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2099,10 +2100,10 @@
           </code>
           <div class="tip" id="2753">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4007-4007" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4007-4007" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2120,10 +2121,10 @@
           </code>
           <div class="tip" id="2754">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4007-4007" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4007-4007" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2141,10 +2142,10 @@
           </code>
           <div class="tip" id="2755">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3924-3924" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3924-3924" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2160,10 +2161,10 @@
           </code>
           <div class="tip" id="2756">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3924-3924" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3924-3924" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2179,10 +2180,10 @@
           </code>
           <div class="tip" id="2757">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3953-3953" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3953-3953" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2200,10 +2201,10 @@
           </code>
           <div class="tip" id="2758">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3953-3953" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3953-3953" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2221,10 +2222,10 @@
           </code>
           <div class="tip" id="2759">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3929-3929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3929-3929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2242,10 +2243,10 @@
           </code>
           <div class="tip" id="2760">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3929-3929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3929-3929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2263,10 +2264,10 @@
           </code>
           <div class="tip" id="2761">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3972-3972" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3972-3972" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2284,10 +2285,10 @@
           </code>
           <div class="tip" id="2762">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3972-3972" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3972-3972" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2305,10 +2306,10 @@
           </code>
           <div class="tip" id="2763">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3977-3977" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3977-3977" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2326,10 +2327,10 @@
           </code>
           <div class="tip" id="2764">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3977-3977" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3977-3977" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2347,10 +2348,10 @@
           </code>
           <div class="tip" id="2765">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4136-4136" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4136-4136" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2368,10 +2369,10 @@
           </code>
           <div class="tip" id="2766">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4136-4136" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4136-4136" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2389,10 +2390,10 @@
           </code>
           <div class="tip" id="2767">
             <strong>Signature:</strong> unit -&gt; Xbins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4099-4099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4099-4099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2408,10 +2409,10 @@
           </code>
           <div class="tip" id="2768">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4099-4099" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4099-4099" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2427,10 +2428,10 @@
           </code>
           <div class="tip" id="2769">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4151-4151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4151-4151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2448,10 +2449,10 @@
           </code>
           <div class="tip" id="2770">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4151-4151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4151-4151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2469,10 +2470,10 @@
           </code>
           <div class="tip" id="2771">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4012-4012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4012-4012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2490,10 +2491,10 @@
           </code>
           <div class="tip" id="2772">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4012-4012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4012-4012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2511,10 +2512,10 @@
           </code>
           <div class="tip" id="2773">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3987-3987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3987-3987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2532,10 +2533,10 @@
           </code>
           <div class="tip" id="2774">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3987-3987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3987-3987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2553,10 +2554,10 @@
           </code>
           <div class="tip" id="2775">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3992-3992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3992-3992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2574,10 +2575,10 @@
           </code>
           <div class="tip" id="2776">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3992-3992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3992-3992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2595,10 +2596,10 @@
           </code>
           <div class="tip" id="2777">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4141-4141" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4141-4141" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2616,10 +2617,10 @@
           </code>
           <div class="tip" id="2778">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4141-4141" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4141-4141" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2637,10 +2638,10 @@
           </code>
           <div class="tip" id="2779">
             <strong>Signature:</strong> unit -&gt; Ybins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4113-4113" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4113-4113" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2656,10 +2657,10 @@
           </code>
           <div class="tip" id="2780">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4113-4113" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4113-4113" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2675,10 +2676,10 @@
           </code>
           <div class="tip" id="2781">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4156-4156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4156-4156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2696,10 +2697,10 @@
           </code>
           <div class="tip" id="2782">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4156-4156" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4156-4156" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2717,10 +2718,10 @@
           </code>
           <div class="tip" id="2783">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4017-4017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4017-4017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2738,10 +2739,10 @@
           </code>
           <div class="tip" id="2784">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4017-4017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4017-4017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2759,10 +2760,10 @@
           </code>
           <div class="tip" id="2785">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3967-3967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3967-3967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2780,10 +2781,10 @@
           </code>
           <div class="tip" id="2786">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3967-3967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3967-3967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2801,10 +2802,10 @@
           </code>
           <div class="tip" id="2787">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4022-4022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4022-4022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2822,10 +2823,10 @@
           </code>
           <div class="tip" id="2788">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4022-4022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4022-4022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2843,10 +2844,10 @@
           </code>
           <div class="tip" id="2789">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4032-4032" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4032-4032" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2864,10 +2865,10 @@
           </code>
           <div class="tip" id="2790">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4032-4032" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4032-4032" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2885,10 +2886,10 @@
           </code>
           <div class="tip" id="2791">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4027-4027" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4027-4027" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2906,10 +2907,10 @@
           </code>
           <div class="tip" id="2792">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4027-4027" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4027-4027" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2927,10 +2928,10 @@
           </code>
           <div class="tip" id="2793">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4057-4057" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4057-4057" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2948,10 +2949,10 @@
           </code>
           <div class="tip" id="2794">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4057-4057" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4057-4057" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2969,10 +2970,10 @@
           </code>
           <div class="tip" id="2795">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4146-4146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4146-4146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2990,10 +2991,10 @@
           </code>
           <div class="tip" id="2796">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4146-4146" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4146-4146" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3015,7 +3016,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -3078,6 +3079,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-insidetextfont.html
+++ b/docs/reference/xplot-plotly-graph-insidetextfont.html
@@ -5,7 +5,7 @@
     <title>Insidetextfont - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Insidetextfont</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2797">
             <strong>Signature:</strong> unit -&gt; Insidetextfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L610-610" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L610-610" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2798">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L627-627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L627-627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2799">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L627-627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L627-627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2800">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L619-619" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L619-619" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="2801">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L619-619" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L619-619" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="2802">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L641-641" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L641-641" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="2803">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L639-639" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L639-639" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="2804">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L640-640" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L640-640" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="2805">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L623-623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L623-623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -256,10 +257,10 @@
           </code>
           <div class="tip" id="2806">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L623-623" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L623-623" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-items.html
+++ b/docs/reference/xplot-plotly-graph-items.html
@@ -5,7 +5,7 @@
     <title>Items - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Items</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2807">
             <strong>Signature:</strong> unit -&gt; Items<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7575-7575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7575-7575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2808">
             <strong>Signature:</strong> unit -&gt; Annotation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7580-7580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7580-7580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2809">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7580-7580" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7580-7580" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2810">
             <strong>Signature:</strong> unit -&gt; Shape<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7584-7584" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7584-7584" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="2811">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7584-7584" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7584-7584" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="2812">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7588-7588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7588-7588" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -197,10 +198,10 @@
           </code>
           <div class="tip" id="2813">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7589-7589" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7589-7589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,7 +220,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -282,6 +283,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-lataxis.html
+++ b/docs/reference/xplot-plotly-graph-lataxis.html
@@ -5,7 +5,7 @@
     <title>Lataxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Lataxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2814">
             <strong>Signature:</strong> unit -&gt; Lataxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6970-6970" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6970-6970" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2815">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6996-6996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6996-6996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2816">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6996-6996" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6996-6996" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2817">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7001-7001" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7001-7001" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2818">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7001-7001" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7001-7001" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2819">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7006-7006" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7006-7006" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2820">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7006-7006" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7006-7006" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2821">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6981-6981" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6981-6981" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2822">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6981-6981" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6981-6981" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2823">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7017-7017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7017-7017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="2824">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7018-7018" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7018-7018" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -307,10 +308,10 @@
           </code>
           <div class="tip" id="2825">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7019-7019" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7019-7019" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -325,10 +326,10 @@
           </code>
           <div class="tip" id="2826">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7014-7014" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7014-7014" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -343,10 +344,10 @@
           </code>
           <div class="tip" id="2827">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7015-7015" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7015-7015" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -361,10 +362,10 @@
           </code>
           <div class="tip" id="2828">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7016-7016" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7016-7016" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -379,10 +380,10 @@
           </code>
           <div class="tip" id="2829">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6986-6986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6986-6986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -400,10 +401,10 @@
           </code>
           <div class="tip" id="2830">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6986-6986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6986-6986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -421,10 +422,10 @@
           </code>
           <div class="tip" id="2831">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6991-6991" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6991-6991" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -442,10 +443,10 @@
           </code>
           <div class="tip" id="2832">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6991-6991" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6991-6991" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -467,7 +468,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -530,6 +531,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-legend.html
+++ b/docs/reference/xplot-plotly-graph-legend.html
@@ -5,7 +5,7 @@
     <title>Legend - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Legend</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2833">
             <strong>Signature:</strong> unit -&gt; Legend<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7234-7234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7234-7234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2834">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7251-7251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7251-7251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2835">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7251-7251" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7251-7251" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2836">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7256-7256" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7256-7256" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2837">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7256-7256" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7256-7256" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2838">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7261-7261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7261-7261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2839">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7261-7261" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7261-7261" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2840">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7265-7265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7265-7265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -248,10 +249,10 @@
           </code>
           <div class="tip" id="2841">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7265-7265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7265-7265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="2842">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7275-7275" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7275-7275" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="2843">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7275-7275" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7275-7275" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2844">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7312-7312" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7312-7312" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="2845">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7313-7313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7313-7313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="2846">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7314-7314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7314-7314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -363,10 +364,10 @@
           </code>
           <div class="tip" id="2847">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7315-7315" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7315-7315" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -381,10 +382,10 @@
           </code>
           <div class="tip" id="2848">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7317-7317" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7317-7317" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -399,10 +400,10 @@
           </code>
           <div class="tip" id="2849">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7318-7318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7318-7318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -417,10 +418,10 @@
           </code>
           <div class="tip" id="2850">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7316-7316" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7316-7316" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="2851">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7319-7319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7319-7319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -453,10 +454,10 @@
           </code>
           <div class="tip" id="2852">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7320-7320" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7320-7320" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -471,10 +472,10 @@
           </code>
           <div class="tip" id="2853">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7321-7321" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7321-7321" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -489,10 +490,10 @@
           </code>
           <div class="tip" id="2854">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7322-7322" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7322-7322" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -507,10 +508,10 @@
           </code>
           <div class="tip" id="2855">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7323-7323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7323-7323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -525,10 +526,10 @@
           </code>
           <div class="tip" id="2856">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7280-7280" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7280-7280" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -546,10 +547,10 @@
           </code>
           <div class="tip" id="2857">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7280-7280" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7280-7280" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -567,10 +568,10 @@
           </code>
           <div class="tip" id="2858">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7270-7270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7270-7270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -588,10 +589,10 @@
           </code>
           <div class="tip" id="2859">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7270-7270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7270-7270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -609,10 +610,10 @@
           </code>
           <div class="tip" id="2860">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7285-7285" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7285-7285" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -630,10 +631,10 @@
           </code>
           <div class="tip" id="2861">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7285-7285" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7285-7285" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -651,10 +652,10 @@
           </code>
           <div class="tip" id="2862">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7290-7290" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7290-7290" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -672,10 +673,10 @@
           </code>
           <div class="tip" id="2863">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7290-7290" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7290-7290" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -693,10 +694,10 @@
           </code>
           <div class="tip" id="2864">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7295-7295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7295-7295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -714,10 +715,10 @@
           </code>
           <div class="tip" id="2865">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7295-7295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7295-7295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="2866">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7300-7300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7300-7300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -756,10 +757,10 @@
           </code>
           <div class="tip" id="2867">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7300-7300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7300-7300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -777,10 +778,10 @@
           </code>
           <div class="tip" id="2868">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7304-7304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7304-7304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -796,10 +797,10 @@
           </code>
           <div class="tip" id="2869">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7304-7304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7304-7304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -819,7 +820,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -882,6 +883,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-lighting.html
+++ b/docs/reference/xplot-plotly-graph-lighting.html
@@ -5,7 +5,7 @@
     <title>Lighting - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Lighting</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2870">
             <strong>Signature:</strong> unit -&gt; Lighting<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L51-51" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L51-51" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2871">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L60-60" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L60-60" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2872">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L60-60" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L60-60" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2873">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="2874">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="2875">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L76-76" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L76-76" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="2876">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L76-76" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L76-76" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="2877">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L72-72" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L72-72" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="2878">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L72-72" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L72-72" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="2879">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L84-84" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L84-84" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -273,10 +274,10 @@
           </code>
           <div class="tip" id="2880">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L85-85" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L85-85" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -291,10 +292,10 @@
           </code>
           <div class="tip" id="2881">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L88-88" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L88-88" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2882">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L87-87" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L87-87" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="2883">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L86-86" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L86-86" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="2884">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="2885">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -387,7 +388,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -450,6 +451,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-line.html
+++ b/docs/reference/xplot-plotly-graph-line.html
@@ -5,7 +5,7 @@
     <title>Line - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Line</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2886">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1417-1417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1417-1417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2887">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1487-1487" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1487-1487" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2888">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1487-1487" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1487-1487" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2889">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1472-1472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1472-1472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2890">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1472-1472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1472-1472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2891">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1477-1477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1477-1477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2892">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1477-1477" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1477-1477" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2893">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1482-1482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1482-1482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2894">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1482-1482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1482-1482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2895">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1437-1437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1437-1437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="2896">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1437-1437" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1437-1437" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2897">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1467-1467" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1467-1467" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="2898">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1467-1467" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1467-1467" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="2899">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1497-1497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1497-1497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -376,10 +377,10 @@
           </code>
           <div class="tip" id="2900">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1497-1497" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1497-1497" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -397,10 +398,10 @@
           </code>
           <div class="tip" id="2901">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1457-1457" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1457-1457" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -418,10 +419,10 @@
           </code>
           <div class="tip" id="2902">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1457-1457" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1457-1457" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="2903">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1507-1507" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1507-1507" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -460,10 +461,10 @@
           </code>
           <div class="tip" id="2904">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1507-1507" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1507-1507" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="2905">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1512-1512" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1512-1512" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="2906">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1512-1512" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1512-1512" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -523,10 +524,10 @@
           </code>
           <div class="tip" id="2907">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1492-1492" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1492-1492" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -544,10 +545,10 @@
           </code>
           <div class="tip" id="2908">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1492-1492" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1492-1492" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -565,10 +566,10 @@
           </code>
           <div class="tip" id="2909">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1447-1447" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1447-1447" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -586,10 +587,10 @@
           </code>
           <div class="tip" id="2910">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1447-1447" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1447-1447" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -607,10 +608,10 @@
           </code>
           <div class="tip" id="2911">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1531-1531" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1531-1531" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -625,10 +626,10 @@
           </code>
           <div class="tip" id="2912">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1528-1528" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1528-1528" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -643,10 +644,10 @@
           </code>
           <div class="tip" id="2913">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1529-1529" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1529-1529" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -661,10 +662,10 @@
           </code>
           <div class="tip" id="2914">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1530-1530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1530-1530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,10 +680,10 @@
           </code>
           <div class="tip" id="2915">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1521-1521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1521-1521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -697,10 +698,10 @@
           </code>
           <div class="tip" id="2916">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1527-1527" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1527-1527" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -715,10 +716,10 @@
           </code>
           <div class="tip" id="2917">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1533-1533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1533-1533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -733,10 +734,10 @@
           </code>
           <div class="tip" id="2918">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1525-1525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1525-1525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -751,10 +752,10 @@
           </code>
           <div class="tip" id="2919">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1535-1535" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1535-1535" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -769,10 +770,10 @@
           </code>
           <div class="tip" id="2920">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1536-1536" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1536-1536" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -787,10 +788,10 @@
           </code>
           <div class="tip" id="2921">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1532-1532" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1532-1532" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -805,10 +806,10 @@
           </code>
           <div class="tip" id="2922">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1523-1523" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1523-1523" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -823,10 +824,10 @@
           </code>
           <div class="tip" id="2923">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1524-1524" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1524-1524" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -841,10 +842,10 @@
           </code>
           <div class="tip" id="2924">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1522-1522" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1522-1522" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -859,10 +860,10 @@
           </code>
           <div class="tip" id="2925">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1534-1534" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1534-1534" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -877,10 +878,10 @@
           </code>
           <div class="tip" id="2926">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1452-1452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1452-1452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -898,10 +899,10 @@
           </code>
           <div class="tip" id="2927">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1452-1452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1452-1452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -919,10 +920,10 @@
           </code>
           <div class="tip" id="2928">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1442-1442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1442-1442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -940,10 +941,10 @@
           </code>
           <div class="tip" id="2929">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1442-1442" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1442-1442" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -961,10 +962,10 @@
           </code>
           <div class="tip" id="2930">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1502-1502" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1502-1502" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -982,10 +983,10 @@
           </code>
           <div class="tip" id="2931">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1502-1502" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1502-1502" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,7 +1008,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1070,6 +1071,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-lonaxis.html
+++ b/docs/reference/xplot-plotly-graph-lonaxis.html
@@ -5,7 +5,7 @@
     <title>Lonaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Lonaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2932">
             <strong>Signature:</strong> unit -&gt; Lonaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6918-6918" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6918-6918" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2933">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6944-6944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6944-6944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2934">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6944-6944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6944-6944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2935">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6949-6949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6949-6949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2936">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6949-6949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6949-6949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2937">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6954-6954" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6954-6954" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2938">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6954-6954" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6954-6954" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2939">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6929-6929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6929-6929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2940">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6929-6929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6929-6929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2941">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6965-6965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6965-6965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -289,10 +290,10 @@
           </code>
           <div class="tip" id="2942">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6966-6966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6966-6966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -307,10 +308,10 @@
           </code>
           <div class="tip" id="2943">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6967-6967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6967-6967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -325,10 +326,10 @@
           </code>
           <div class="tip" id="2944">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6962-6962" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6962-6962" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -343,10 +344,10 @@
           </code>
           <div class="tip" id="2945">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6963-6963" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6963-6963" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -361,10 +362,10 @@
           </code>
           <div class="tip" id="2946">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6964-6964" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6964-6964" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -379,10 +380,10 @@
           </code>
           <div class="tip" id="2947">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6934-6934" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6934-6934" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -400,10 +401,10 @@
           </code>
           <div class="tip" id="2948">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6934-6934" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6934-6934" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -421,10 +422,10 @@
           </code>
           <div class="tip" id="2949">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6939-6939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6939-6939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -442,10 +443,10 @@
           </code>
           <div class="tip" id="2950">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6939-6939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6939-6939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -467,7 +468,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -530,6 +531,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-margin.html
+++ b/docs/reference/xplot-plotly-graph-margin.html
@@ -5,7 +5,7 @@
     <title>Margin - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Margin</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2951">
             <strong>Signature:</strong> unit -&gt; Margin<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5530-5530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5530-5530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2952">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5565-5565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5565-5565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="2953">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5565-5565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5565-5565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="2954">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5556-5556" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5556-5556" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="2955">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5556-5556" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5556-5556" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="2956">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5541-5541" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5541-5541" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="2957">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5541-5541" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5541-5541" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="2958">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5561-5561" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5561-5561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="2959">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5561-5561" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5561-5561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="2960">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5546-5546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5546-5546" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="2961">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5546-5546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5546-5546" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="2962">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5578-5578" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5578-5578" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -327,10 +328,10 @@
           </code>
           <div class="tip" id="2963">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5576-5576" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5576-5576" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -345,10 +346,10 @@
           </code>
           <div class="tip" id="2964">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5573-5573" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5573-5573" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -363,10 +364,10 @@
           </code>
           <div class="tip" id="2965">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5577-5577" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5577-5577" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -381,10 +382,10 @@
           </code>
           <div class="tip" id="2966">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5574-5574" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5574-5574" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -399,10 +400,10 @@
           </code>
           <div class="tip" id="2967">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5575-5575" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5575-5575" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -417,10 +418,10 @@
           </code>
           <div class="tip" id="2968">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5551-5551" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5551-5551" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -438,10 +439,10 @@
           </code>
           <div class="tip" id="2969">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5551-5551" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5551-5551" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -463,7 +464,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -526,6 +527,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-marker.html
+++ b/docs/reference/xplot-plotly-graph-marker.html
@@ -5,7 +5,7 @@
     <title>Marker - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Marker</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="2970">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1538-1538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1538-1538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="2971">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1627-1627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1627-1627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="2972">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1627-1627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1627-1627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="2973">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1612-1612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1612-1612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="2974">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1612-1612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1612-1612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="2975">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1617-1617" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1617-1617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="2976">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1617-1617" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1617-1617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="2977">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1622-1622" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1622-1622" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="2978">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1622-1622" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1622-1622" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="2979">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1582-1582" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1582-1582" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="2980">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1582-1582" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1582-1582" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="2981">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1645-1645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1645-1645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="2982">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1645-1645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1645-1645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="2983">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1679-1679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1679-1679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="2984">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1679-1679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1679-1679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="2985">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1607-1607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1607-1607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,10 +415,10 @@
           </code>
           <div class="tip" id="2986">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1607-1607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1607-1607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="2987">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1669-1669" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1669-1669" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +457,10 @@
           </code>
           <div class="tip" id="2988">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1669-1669" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1669-1669" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="2989">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1684-1684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1684-1684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -498,10 +499,10 @@
           </code>
           <div class="tip" id="2990">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1684-1684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1684-1684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -519,10 +520,10 @@
           </code>
           <div class="tip" id="2991">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1641-1641" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1641-1641" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -538,10 +539,10 @@
           </code>
           <div class="tip" id="2992">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1641-1641" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1641-1641" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="2993">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1587-1587" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1587-1587" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="2994">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1587-1587" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1587-1587" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="2995">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1572-1572" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1572-1572" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -620,10 +621,10 @@
           </code>
           <div class="tip" id="2996">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1572-1572" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1572-1572" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="2997">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1659-1659" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1659-1659" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="2998">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1659-1659" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1659-1659" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="2999">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1674-1674" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1674-1674" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -704,10 +705,10 @@
           </code>
           <div class="tip" id="3000">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1674-1674" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1674-1674" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="3001">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1632-1632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1632-1632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -746,10 +747,10 @@
           </code>
           <div class="tip" id="3002">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1632-1632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1632-1632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -767,10 +768,10 @@
           </code>
           <div class="tip" id="3003">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1701-1701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1701-1701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -785,10 +786,10 @@
           </code>
           <div class="tip" id="3004">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1698-1698" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1698-1698" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -803,10 +804,10 @@
           </code>
           <div class="tip" id="3005">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1699-1699" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1699-1699" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -821,10 +822,10 @@
           </code>
           <div class="tip" id="3006">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1700-1700" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1700-1700" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -839,10 +840,10 @@
           </code>
           <div class="tip" id="3007">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1692-1692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1692-1692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -857,10 +858,10 @@
           </code>
           <div class="tip" id="3008">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1705-1705" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1705-1705" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -875,10 +876,10 @@
           </code>
           <div class="tip" id="3009">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1712-1712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1712-1712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -893,10 +894,10 @@
           </code>
           <div class="tip" id="3010">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1697-1697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1697-1697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -911,10 +912,10 @@
           </code>
           <div class="tip" id="3011">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1710-1710" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1710-1710" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -929,10 +930,10 @@
           </code>
           <div class="tip" id="3012">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1713-1713" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1713-1713" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -947,10 +948,10 @@
           </code>
           <div class="tip" id="3013">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1704-1704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1704-1704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -965,10 +966,10 @@
           </code>
           <div class="tip" id="3014">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1693-1693" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1693-1693" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -983,10 +984,10 @@
           </code>
           <div class="tip" id="3015">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1690-1690" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1690-1690" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1001,10 +1002,10 @@
           </code>
           <div class="tip" id="3016">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1708-1708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1708-1708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1019,10 +1020,10 @@
           </code>
           <div class="tip" id="3017">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1711-1711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1711-1711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1037,10 +1038,10 @@
           </code>
           <div class="tip" id="3018">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1702-1702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1702-1702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1055,10 +1056,10 @@
           </code>
           <div class="tip" id="3019">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1703-1703" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1703-1703" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1073,10 +1074,10 @@
           </code>
           <div class="tip" id="3020">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1691-1691" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1691-1691" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1091,10 +1092,10 @@
           </code>
           <div class="tip" id="3021">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1695-1695" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1695-1695" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1109,10 +1110,10 @@
           </code>
           <div class="tip" id="3022">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1696-1696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1696-1696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1127,10 +1128,10 @@
           </code>
           <div class="tip" id="3023">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1694-1694" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1694-1694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1145,10 +1146,10 @@
           </code>
           <div class="tip" id="3024">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1709-1709" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1709-1709" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1163,10 +1164,10 @@
           </code>
           <div class="tip" id="3025">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1689-1689" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1689-1689" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1181,10 +1182,10 @@
           </code>
           <div class="tip" id="3026">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1707-1707" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1707-1707" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1199,10 +1200,10 @@
           </code>
           <div class="tip" id="3027">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1637-1637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1637-1637" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1220,10 +1221,10 @@
           </code>
           <div class="tip" id="3028">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1637-1637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1637-1637" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1241,10 +1242,10 @@
           </code>
           <div class="tip" id="3029">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1577-1577" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1577-1577" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1262,10 +1263,10 @@
           </code>
           <div class="tip" id="3030">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1577-1577" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1577-1577" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1283,10 +1284,10 @@
           </code>
           <div class="tip" id="3031">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1597-1597" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1597-1597" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1304,10 +1305,10 @@
           </code>
           <div class="tip" id="3032">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1597-1597" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1597-1597" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1325,10 +1326,10 @@
           </code>
           <div class="tip" id="3033">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1602-1602" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1602-1602" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1346,10 +1347,10 @@
           </code>
           <div class="tip" id="3034">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1602-1602" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1602-1602" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1367,10 +1368,10 @@
           </code>
           <div class="tip" id="3035">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1592-1592" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1592-1592" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1388,10 +1389,10 @@
           </code>
           <div class="tip" id="3036">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1592-1592" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1592-1592" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1409,10 +1410,10 @@
           </code>
           <div class="tip" id="3037">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1664-1664" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1664-1664" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1430,10 +1431,10 @@
           </code>
           <div class="tip" id="3038">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1664-1664" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1664-1664" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1451,10 +1452,10 @@
           </code>
           <div class="tip" id="3039">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1567-1567" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1567-1567" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1472,10 +1473,10 @@
           </code>
           <div class="tip" id="3040">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1567-1567" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1567-1567" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1493,10 +1494,10 @@
           </code>
           <div class="tip" id="3041">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1654-1654" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1654-1654" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1514,10 +1515,10 @@
           </code>
           <div class="tip" id="3042">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1654-1654" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1654-1654" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1539,7 +1540,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1602,6 +1603,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-mesh3d.html
+++ b/docs/reference/xplot-plotly-graph-mesh3d.html
@@ -5,7 +5,7 @@
     <title>Mesh3d - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Mesh3d</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3043">
             <strong>Signature:</strong> unit -&gt; Mesh3d<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4627-4627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4627-4627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3044">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4738-4738" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4738-4738" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3045">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4738-4738" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4738-4738" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3046">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4746-4746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4746-4746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="3047">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4746-4746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4746-4746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="3048">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4785-4785" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4785-4785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="3049">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4785-4785" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4785-4785" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="3050">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4767-4767" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4767-4767" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -238,10 +239,10 @@
           </code>
           <div class="tip" id="3051">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4767-4767" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4767-4767" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -259,10 +260,10 @@
           </code>
           <div class="tip" id="3052">
             <strong>Signature:</strong> unit -&gt; Contour<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4762-4762" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4762-4762" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -278,10 +279,10 @@
           </code>
           <div class="tip" id="3053">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4762-4762" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4762-4762" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="3054">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4734-4734" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4734-4734" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="3055">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4734-4734" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4734-4734" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="3056">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4754-4754" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4754-4754" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -354,10 +355,10 @@
           </code>
           <div class="tip" id="3057">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4754-4754" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4754-4754" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -373,10 +374,10 @@
           </code>
           <div class="tip" id="3058">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4835-4835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4835-4835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -394,10 +395,10 @@
           </code>
           <div class="tip" id="3059">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4835-4835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4835-4835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -415,10 +416,10 @@
           </code>
           <div class="tip" id="3060">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4758-4758" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4758-4758" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -434,10 +435,10 @@
           </code>
           <div class="tip" id="3061">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4758-4758" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4758-4758" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -453,10 +454,10 @@
           </code>
           <div class="tip" id="3062">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4702-4702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4702-4702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -474,10 +475,10 @@
           </code>
           <div class="tip" id="3063">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4702-4702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4702-4702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -495,10 +496,10 @@
           </code>
           <div class="tip" id="3064">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4722-4722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4722-4722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -514,10 +515,10 @@
           </code>
           <div class="tip" id="3065">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4722-4722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4722-4722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="3066">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4742-4742" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4742-4742" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -552,10 +553,10 @@
           </code>
           <div class="tip" id="3067">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4742-4742" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4742-4742" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -571,10 +572,10 @@
           </code>
           <div class="tip" id="3068">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4825-4825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4825-4825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -592,10 +593,10 @@
           </code>
           <div class="tip" id="3069">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4825-4825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4825-4825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -613,10 +614,10 @@
           </code>
           <div class="tip" id="3070">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4810-4810" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4810-4810" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -634,10 +635,10 @@
           </code>
           <div class="tip" id="3071">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4810-4810" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4810-4810" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -655,10 +656,10 @@
           </code>
           <div class="tip" id="3072">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4726-4726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4726-4726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -674,10 +675,10 @@
           </code>
           <div class="tip" id="3073">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4726-4726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4726-4726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -693,10 +694,10 @@
           </code>
           <div class="tip" id="3074">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4815-4815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4815-4815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -714,10 +715,10 @@
           </code>
           <div class="tip" id="3075">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4815-4815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4815-4815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="3076">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4730-4730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4730-4730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -754,10 +755,10 @@
           </code>
           <div class="tip" id="3077">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4730-4730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4730-4730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -773,10 +774,10 @@
           </code>
           <div class="tip" id="3078">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4820-4820" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4820-4820" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -794,10 +795,10 @@
           </code>
           <div class="tip" id="3079">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4820-4820" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4820-4820" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -815,10 +816,10 @@
           </code>
           <div class="tip" id="3080">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4684-4684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4684-4684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -836,10 +837,10 @@
           </code>
           <div class="tip" id="3081">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4684-4684" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4684-4684" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -857,10 +858,10 @@
           </code>
           <div class="tip" id="3082">
             <strong>Signature:</strong> unit -&gt; Lighting<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4781-4781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4781-4781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -876,10 +877,10 @@
           </code>
           <div class="tip" id="3083">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4781-4781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4781-4781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -895,10 +896,10 @@
           </code>
           <div class="tip" id="3084">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4688-4688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4688-4688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -914,10 +915,10 @@
           </code>
           <div class="tip" id="3085">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4688-4688" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4688-4688" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="3086">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4772-4772" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4772-4772" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -954,10 +955,10 @@
           </code>
           <div class="tip" id="3087">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4772-4772" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4772-4772" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -975,10 +976,10 @@
           </code>
           <div class="tip" id="3088">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4790-4790" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4790-4790" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -996,10 +997,10 @@
           </code>
           <div class="tip" id="3089">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4790-4790" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4790-4790" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1017,10 +1018,10 @@
           </code>
           <div class="tip" id="3090">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4855-4855" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4855-4855" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1035,10 +1036,10 @@
           </code>
           <div class="tip" id="3091">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4857-4857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4857-4857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1053,10 +1054,10 @@
           </code>
           <div class="tip" id="3092">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4866-4866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4866-4866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1071,10 +1072,10 @@
           </code>
           <div class="tip" id="3093">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4862-4862" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4862-4862" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1089,10 +1090,10 @@
           </code>
           <div class="tip" id="3094">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4861-4861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4861-4861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1107,10 +1108,10 @@
           </code>
           <div class="tip" id="3095">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4854-4854" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4854-4854" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="3096">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4859-4859" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4859-4859" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1143,10 +1144,10 @@
           </code>
           <div class="tip" id="3097">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4876-4876" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4876-4876" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1161,10 +1162,10 @@
           </code>
           <div class="tip" id="3098">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4860-4860" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4860-4860" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1179,10 +1180,10 @@
           </code>
           <div class="tip" id="3099">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4846-4846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4846-4846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1197,10 +1198,10 @@
           </code>
           <div class="tip" id="3100">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4851-4851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4851-4851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1215,10 +1216,10 @@
           </code>
           <div class="tip" id="3101">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4856-4856" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4856-4856" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1233,10 +1234,10 @@
           </code>
           <div class="tip" id="3102">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4874-4874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4874-4874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1251,10 +1252,10 @@
           </code>
           <div class="tip" id="3103">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4871-4871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4871-4871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1269,10 +1270,10 @@
           </code>
           <div class="tip" id="3104">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4852-4852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4852-4852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1287,10 +1288,10 @@
           </code>
           <div class="tip" id="3105">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4872-4872" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4872-4872" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1305,10 +1306,10 @@
           </code>
           <div class="tip" id="3106">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4853-4853" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4853-4853" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1323,10 +1324,10 @@
           </code>
           <div class="tip" id="3107">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4873-4873" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4873-4873" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1341,10 +1342,10 @@
           </code>
           <div class="tip" id="3108">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4842-4842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4842-4842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1359,10 +1360,10 @@
           </code>
           <div class="tip" id="3109">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4865-4865" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4865-4865" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="3110">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4843-4843" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4843-4843" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1395,10 +1396,10 @@
           </code>
           <div class="tip" id="3111">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4863-4863" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4863-4863" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1413,10 +1414,10 @@
           </code>
           <div class="tip" id="3112">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4867-4867" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4867-4867" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1431,10 +1432,10 @@
           </code>
           <div class="tip" id="3113">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4841-4841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4841-4841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1449,10 +1450,10 @@
           </code>
           <div class="tip" id="3114">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4864-4864" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4864-4864" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1467,10 +1468,10 @@
           </code>
           <div class="tip" id="3115">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4847-4847" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4847-4847" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1485,10 +1486,10 @@
           </code>
           <div class="tip" id="3116">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4839-4839" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4839-4839" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1503,10 +1504,10 @@
           </code>
           <div class="tip" id="3117">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4845-4845" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4845-4845" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1521,10 +1522,10 @@
           </code>
           <div class="tip" id="3118">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4858-4858" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4858-4858" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1539,10 +1540,10 @@
           </code>
           <div class="tip" id="3119">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4875-4875" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4875-4875" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1557,10 +1558,10 @@
           </code>
           <div class="tip" id="3120">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4840-4840" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4840-4840" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1575,10 +1576,10 @@
           </code>
           <div class="tip" id="3121">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4848-4848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4848-4848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1593,10 +1594,10 @@
           </code>
           <div class="tip" id="3122">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4868-4868" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4868-4868" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1611,10 +1612,10 @@
           </code>
           <div class="tip" id="3123">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4849-4849" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4849-4849" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1629,10 +1630,10 @@
           </code>
           <div class="tip" id="3124">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4869-4869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4869-4869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1647,10 +1648,10 @@
           </code>
           <div class="tip" id="3125">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4850-4850" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4850-4850" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1665,10 +1666,10 @@
           </code>
           <div class="tip" id="3126">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4870-4870" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4870-4870" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1683,10 +1684,10 @@
           </code>
           <div class="tip" id="3127">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4679-4679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4679-4679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1704,10 +1705,10 @@
           </code>
           <div class="tip" id="3128">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4679-4679" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4679-4679" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1725,10 +1726,10 @@
           </code>
           <div class="tip" id="3129">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4777-4777" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4777-4777" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1746,10 +1747,10 @@
           </code>
           <div class="tip" id="3130">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4777-4777" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4777-4777" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1767,10 +1768,10 @@
           </code>
           <div class="tip" id="3131">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4706-4706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4706-4706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1786,10 +1787,10 @@
           </code>
           <div class="tip" id="3132">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4706-4706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4706-4706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1805,10 +1806,10 @@
           </code>
           <div class="tip" id="3133">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4669-4669" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4669-4669" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1824,10 +1825,10 @@
           </code>
           <div class="tip" id="3134">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4669-4669" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4669-4669" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1843,10 +1844,10 @@
           </code>
           <div class="tip" id="3135">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4697-4697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4697-4697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1864,10 +1865,10 @@
           </code>
           <div class="tip" id="3136">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4697-4697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4697-4697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1885,10 +1886,10 @@
           </code>
           <div class="tip" id="3137">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4750-4750" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4750-4750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1904,10 +1905,10 @@
           </code>
           <div class="tip" id="3138">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4750-4750" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4750-4750" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1923,10 +1924,10 @@
           </code>
           <div class="tip" id="3139">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4830-4830" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4830-4830" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1944,10 +1945,10 @@
           </code>
           <div class="tip" id="3140">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4830-4830" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4830-4830" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1965,10 +1966,10 @@
           </code>
           <div class="tip" id="3141">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4674-4674" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4674-4674" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1986,10 +1987,10 @@
           </code>
           <div class="tip" id="3142">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4674-4674" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4674-4674" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2007,10 +2008,10 @@
           </code>
           <div class="tip" id="3143">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4710-4710" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4710-4710" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2026,10 +2027,10 @@
           </code>
           <div class="tip" id="3144">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4710-4710" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4710-4710" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2045,10 +2046,10 @@
           </code>
           <div class="tip" id="3145">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4795-4795" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4795-4795" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2066,10 +2067,10 @@
           </code>
           <div class="tip" id="3146">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4795-4795" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4795-4795" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2087,10 +2088,10 @@
           </code>
           <div class="tip" id="3147">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4714-4714" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4714-4714" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2106,10 +2107,10 @@
           </code>
           <div class="tip" id="3148">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4714-4714" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4714-4714" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2125,10 +2126,10 @@
           </code>
           <div class="tip" id="3149">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4800-4800" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4800-4800" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2146,10 +2147,10 @@
           </code>
           <div class="tip" id="3150">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4800-4800" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4800-4800" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2167,10 +2168,10 @@
           </code>
           <div class="tip" id="3151">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4718-4718" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4718-4718" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2186,10 +2187,10 @@
           </code>
           <div class="tip" id="3152">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4718-4718" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4718-4718" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2205,10 +2206,10 @@
           </code>
           <div class="tip" id="3153">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4805-4805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4805-4805" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2226,10 +2227,10 @@
           </code>
           <div class="tip" id="3154">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4805-4805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4805-4805" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2251,7 +2252,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2314,6 +2315,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-outsidetextfont.html
+++ b/docs/reference/xplot-plotly-graph-outsidetextfont.html
@@ -5,7 +5,7 @@
     <title>Outsidetextfont - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Outsidetextfont</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3155">
             <strong>Signature:</strong> unit -&gt; Outsidetextfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L645-645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L645-645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3156">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L662-662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L662-662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3157">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L662-662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L662-662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3158">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L654-654" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L654-654" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3159">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L654-654" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L654-654" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3160">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L676-676" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L676-676" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="3161">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L674-674" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L674-674" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="3162">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L675-675" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L675-675" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="3163">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L658-658" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L658-658" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -256,10 +257,10 @@
           </code>
           <div class="tip" id="3164">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L658-658" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L658-658" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-pie.html
+++ b/docs/reference/xplot-plotly-graph-pie.html
@@ -5,7 +5,7 @@
     <title>Pie - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Pie</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3165">
             <strong>Signature:</strong> unit -&gt; Pie<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3342-3342" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3342-3342" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3166">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3491-3491" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3491-3491" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3167">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3491-3491" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3491-3491" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3168">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3431-3431" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3431-3431" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="3169">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3431-3431" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3431-3431" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="3170">
             <strong>Signature:</strong> unit -&gt; Domain<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3476-3476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3476-3476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -206,10 +207,10 @@
           </code>
           <div class="tip" id="3171">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3476-3476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3476-3476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3172">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3481-3481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3481-3481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="3173">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3481-3481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3481-3481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="3174">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3412-3412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3412-3412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -288,10 +289,10 @@
           </code>
           <div class="tip" id="3175">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3412-3412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3412-3412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -309,10 +310,10 @@
           </code>
           <div class="tip" id="3176">
             <strong>Signature:</strong> unit -&gt; Insidetextfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3468-3468" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3468-3468" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -328,10 +329,10 @@
           </code>
           <div class="tip" id="3177">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3468-3468" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3468-3468" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="3178">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3426-3426" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3426-3426" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="3179">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3426-3426" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3426-3426" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="3180">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3421-3421" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3421-3421" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="3181">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3421-3421" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3421-3421" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3182">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3506-3506" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3506-3506" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="3183">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3506-3506" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3506-3506" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="3184">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3393-3393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3393-3393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="3185">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3393-3393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3393-3393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="3186">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3440-3440" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3440-3440" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -534,10 +535,10 @@
           </code>
           <div class="tip" id="3187">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3440-3440" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3440-3440" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="3188">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3398-3398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3398-3398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -574,10 +575,10 @@
           </code>
           <div class="tip" id="3189">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3398-3398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3398-3398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -595,10 +596,10 @@
           </code>
           <div class="tip" id="3190">
             <strong>Signature:</strong> unit -&gt; Outsidetextfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3472-3472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3472-3472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -614,10 +615,10 @@
           </code>
           <div class="tip" id="3191">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3472-3472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3472-3472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="3192">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3501-3501" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3501-3501" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="3193">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3501-3501" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3501-3501" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="3194">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3526-3526" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3526-3526" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -696,10 +697,10 @@
           </code>
           <div class="tip" id="3195">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3526-3526" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3526-3526" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="3196">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3496-3496" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3496-3496" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -738,10 +739,10 @@
           </code>
           <div class="tip" id="3197">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3496-3496" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3496-3496" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -759,10 +760,10 @@
           </code>
           <div class="tip" id="3198">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3450-3450" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3450-3450" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -780,10 +781,10 @@
           </code>
           <div class="tip" id="3199">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3450-3450" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3450-3450" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -801,10 +802,10 @@
           </code>
           <div class="tip" id="3200">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3554-3554" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3554-3554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -819,10 +820,10 @@
           </code>
           <div class="tip" id="3201">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3541-3541" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3541-3541" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -837,10 +838,10 @@
           </code>
           <div class="tip" id="3202">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3551-3551" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3551-3551" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -855,10 +856,10 @@
           </code>
           <div class="tip" id="3203">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3552-3552" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3552-3552" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -873,10 +874,10 @@
           </code>
           <div class="tip" id="3204">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3537-3537" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3537-3537" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -891,10 +892,10 @@
           </code>
           <div class="tip" id="3205">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3549-3549" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3549-3549" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -909,10 +910,10 @@
           </code>
           <div class="tip" id="3206">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3540-3540" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3540-3540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -927,10 +928,10 @@
           </code>
           <div class="tip" id="3207">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3539-3539" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3539-3539" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -945,10 +946,10 @@
           </code>
           <div class="tip" id="3208">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3557-3557" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3557-3557" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -963,10 +964,10 @@
           </code>
           <div class="tip" id="3209">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3533-3533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3533-3533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -981,10 +982,10 @@
           </code>
           <div class="tip" id="3210">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3543-3543" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3543-3543" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -999,10 +1000,10 @@
           </code>
           <div class="tip" id="3211">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3534-3534" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3534-3534" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1017,10 +1018,10 @@
           </code>
           <div class="tip" id="3212">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3550-3550" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3550-3550" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1035,10 +1036,10 @@
           </code>
           <div class="tip" id="3213">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3556-3556" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3556-3556" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1053,10 +1054,10 @@
           </code>
           <div class="tip" id="3214">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3561-3561" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3561-3561" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1071,10 +1072,10 @@
           </code>
           <div class="tip" id="3215">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3555-3555" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3555-3555" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1089,10 +1090,10 @@
           </code>
           <div class="tip" id="3216">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3545-3545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3545-3545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1107,10 +1108,10 @@
           </code>
           <div class="tip" id="3217">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3532-3532" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3532-3532" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="3218">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3553-3553" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3553-3553" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1143,10 +1144,10 @@
           </code>
           <div class="tip" id="3219">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3538-3538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3538-3538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1161,10 +1162,10 @@
           </code>
           <div class="tip" id="3220">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3544-3544" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3544-3544" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1179,10 +1180,10 @@
           </code>
           <div class="tip" id="3221">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3548-3548" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3548-3548" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1197,10 +1198,10 @@
           </code>
           <div class="tip" id="3222">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3546-3546" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3546-3546" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1215,10 +1216,10 @@
           </code>
           <div class="tip" id="3223">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3547-3547" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3547-3547" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1233,10 +1234,10 @@
           </code>
           <div class="tip" id="3224">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3560-3560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3560-3560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1251,10 +1252,10 @@
           </code>
           <div class="tip" id="3225">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3559-3559" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3559-3559" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1269,10 +1270,10 @@
           </code>
           <div class="tip" id="3226">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3530-3530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3530-3530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1287,10 +1288,10 @@
           </code>
           <div class="tip" id="3227">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3536-3536" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3536-3536" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1305,10 +1306,10 @@
           </code>
           <div class="tip" id="3228">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3542-3542" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3542-3542" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1323,10 +1324,10 @@
           </code>
           <div class="tip" id="3229">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3558-3558" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3558-3558" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1341,10 +1342,10 @@
           </code>
           <div class="tip" id="3230">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3531-3531" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3531-3531" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1359,10 +1360,10 @@
           </code>
           <div class="tip" id="3231">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3388-3388" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3388-3388" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1380,10 +1381,10 @@
           </code>
           <div class="tip" id="3232">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3388-3388" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3388-3388" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1401,10 +1402,10 @@
           </code>
           <div class="tip" id="3233">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3486-3486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3486-3486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1422,10 +1423,10 @@
           </code>
           <div class="tip" id="3234">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3486-3486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3486-3486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1443,10 +1444,10 @@
           </code>
           <div class="tip" id="3235">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3416-3416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3416-3416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1462,10 +1463,10 @@
           </code>
           <div class="tip" id="3236">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3416-3416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3416-3416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1481,10 +1482,10 @@
           </code>
           <div class="tip" id="3237">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3445-3445" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3445-3445" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1502,10 +1503,10 @@
           </code>
           <div class="tip" id="3238">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3445-3445" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3445-3445" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1523,10 +1524,10 @@
           </code>
           <div class="tip" id="3239">
             <strong>Signature:</strong> unit -&gt; Textfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3464-3464" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3464-3464" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1542,10 +1543,10 @@
           </code>
           <div class="tip" id="3240">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3464-3464" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3464-3464" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1561,10 +1562,10 @@
           </code>
           <div class="tip" id="3241">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3455-3455" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3455-3455" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1582,10 +1583,10 @@
           </code>
           <div class="tip" id="3242">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3455-3455" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3455-3455" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1603,10 +1604,10 @@
           </code>
           <div class="tip" id="3243">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3460-3460" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3460-3460" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1624,10 +1625,10 @@
           </code>
           <div class="tip" id="3244">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3460-3460" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3460-3460" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1645,10 +1646,10 @@
           </code>
           <div class="tip" id="3245">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3521-3521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3521-3521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1666,10 +1667,10 @@
           </code>
           <div class="tip" id="3246">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3521-3521" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3521-3521" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1687,10 +1688,10 @@
           </code>
           <div class="tip" id="3247">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3516-3516" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3516-3516" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1708,10 +1709,10 @@
           </code>
           <div class="tip" id="3248">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3516-3516" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3516-3516" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1729,10 +1730,10 @@
           </code>
           <div class="tip" id="3249">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3378-3378" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3378-3378" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1748,10 +1749,10 @@
           </code>
           <div class="tip" id="3250">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3378-3378" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3378-3378" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1767,10 +1768,10 @@
           </code>
           <div class="tip" id="3251">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3407-3407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3407-3407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1788,10 +1789,10 @@
           </code>
           <div class="tip" id="3252">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3407-3407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3407-3407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1809,10 +1810,10 @@
           </code>
           <div class="tip" id="3253">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3436-3436" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3436-3436" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1830,10 +1831,10 @@
           </code>
           <div class="tip" id="3254">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3436-3436" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3436-3436" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1851,10 +1852,10 @@
           </code>
           <div class="tip" id="3255">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3511-3511" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3511-3511" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1872,10 +1873,10 @@
           </code>
           <div class="tip" id="3256">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3511-3511" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3511-3511" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1893,10 +1894,10 @@
           </code>
           <div class="tip" id="3257">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3383-3383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3383-3383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1914,10 +1915,10 @@
           </code>
           <div class="tip" id="3258">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3383-3383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L3383-3383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1939,7 +1940,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2002,6 +2003,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-project.html
+++ b/docs/reference/xplot-plotly-graph-project.html
@@ -5,7 +5,7 @@
     <title>Project - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Project</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3259">
             <strong>Signature:</strong> unit -&gt; Project<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L242-242" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L242-242" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3260">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L268-268" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L268-268" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="3261">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L269-269" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L269-269" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="3262">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L270-270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L270-270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="3263">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L250-250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L250-250" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -178,10 +179,10 @@
           </code>
           <div class="tip" id="3264">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L250-250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L250-250" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -199,10 +200,10 @@
           </code>
           <div class="tip" id="3265">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L255-255" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L255-255" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -220,10 +221,10 @@
           </code>
           <div class="tip" id="3266">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L255-255" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L255-255" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -241,10 +242,10 @@
           </code>
           <div class="tip" id="3267">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L260-260" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L260-260" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -262,10 +263,10 @@
           </code>
           <div class="tip" id="3268">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L260-260" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L260-260" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -287,7 +288,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -350,6 +351,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-projection.html
+++ b/docs/reference/xplot-plotly-graph-projection.html
@@ -5,7 +5,7 @@
     <title>Projection - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Projection</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3269">
             <strong>Signature:</strong> unit -&gt; Projection<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L492-492" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L492-492" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3270">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L529-529" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L529-529" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3271">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L529-529" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L529-529" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3272">
             <strong>Signature:</strong> unit -&gt; Rotation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L524-524" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L524-524" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="3273">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L524-524" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L524-524" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3274">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L534-534" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L534-534" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="3275">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L534-534" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L534-534" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3276">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L544-544" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L544-544" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -243,10 +244,10 @@
           </code>
           <div class="tip" id="3277">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L543-543" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L543-543" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -261,10 +262,10 @@
           </code>
           <div class="tip" id="3278">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L545-545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L545-545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,10 +280,10 @@
           </code>
           <div class="tip" id="3279">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L542-542" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L542-542" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="3280">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L538-538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L538-538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -315,10 +316,10 @@
           </code>
           <div class="tip" id="3281">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L539-539" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L539-539" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -333,10 +334,10 @@
           </code>
           <div class="tip" id="3282">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L540-540" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L540-540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="3283">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L520-520" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L520-520" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="3284">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L520-520" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L520-520" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="3285">
             <strong>Signature:</strong> unit -&gt; X<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L503-503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L503-503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -412,10 +413,10 @@
           </code>
           <div class="tip" id="3286">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L503-503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L503-503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3287">
             <strong>Signature:</strong> unit -&gt; Y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L507-507" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L507-507" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -450,10 +451,10 @@
           </code>
           <div class="tip" id="3288">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L507-507" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L507-507" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -469,10 +470,10 @@
           </code>
           <div class="tip" id="3289">
             <strong>Signature:</strong> unit -&gt; Z<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L511-511" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L511-511" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -488,10 +489,10 @@
           </code>
           <div class="tip" id="3290">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L511-511" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L511-511" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,7 +512,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -574,6 +575,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-radialaxis.html
+++ b/docs/reference/xplot-plotly-graph-radialaxis.html
@@ -5,7 +5,7 @@
     <title>Radialaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Radialaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3291">
             <strong>Signature:</strong> unit -&gt; Radialaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7629-7629" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7629-7629" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3292">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7650-7650" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7650-7650" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3293">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7650-7650" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7650-7650" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3294">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7689-7689" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7689-7689" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="3295">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7689-7689" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7689-7689" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3296">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7655-7655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7655-7655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="3297">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7655-7655" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7655-7655" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3298">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7645-7645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7645-7645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="3299">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7645-7645" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7645-7645" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="3300">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7703-7703" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7703-7703" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -285,10 +286,10 @@
           </code>
           <div class="tip" id="3301">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7711-7711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7711-7711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -303,10 +304,10 @@
           </code>
           <div class="tip" id="3302">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7704-7704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7704-7704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -321,10 +322,10 @@
           </code>
           <div class="tip" id="3303">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7702-7702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7702-7702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -339,10 +340,10 @@
           </code>
           <div class="tip" id="3304">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7705-7705" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7705-7705" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -357,10 +358,10 @@
           </code>
           <div class="tip" id="3305">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7706-7706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7706-7706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -375,10 +376,10 @@
           </code>
           <div class="tip" id="3306">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7709-7709" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7709-7709" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="3307">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7708-7708" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7708-7708" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -411,10 +412,10 @@
           </code>
           <div class="tip" id="3308">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7707-7707" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7707-7707" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -429,10 +430,10 @@
           </code>
           <div class="tip" id="3309">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7710-7710" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7710-7710" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -447,10 +448,10 @@
           </code>
           <div class="tip" id="3310">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7712-7712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7712-7712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -465,10 +466,10 @@
           </code>
           <div class="tip" id="3311">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7660-7660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7660-7660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -486,10 +487,10 @@
           </code>
           <div class="tip" id="3312">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7660-7660" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7660-7660" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -507,10 +508,10 @@
           </code>
           <div class="tip" id="3313">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7665-7665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7665-7665" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -528,10 +529,10 @@
           </code>
           <div class="tip" id="3314">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7665-7665" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7665-7665" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -549,10 +550,10 @@
           </code>
           <div class="tip" id="3315">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7680-7680" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7680-7680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -570,10 +571,10 @@
           </code>
           <div class="tip" id="3316">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7680-7680" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7680-7680" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="3317">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7675-7675" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7675-7675" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -612,10 +613,10 @@
           </code>
           <div class="tip" id="3318">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7675-7675" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7675-7675" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="3319">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7670-7670" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7670-7670" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="3320">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7670-7670" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7670-7670" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="3321">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7685-7685" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7685-7685" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -696,10 +697,10 @@
           </code>
           <div class="tip" id="3322">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7685-7685" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7685-7685" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="3323">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7694-7694" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7694-7694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -738,10 +739,10 @@
           </code>
           <div class="tip" id="3324">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7694-7694" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7694-7694" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -763,7 +764,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -826,6 +827,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-rotation.html
+++ b/docs/reference/xplot-plotly-graph-rotation.html
@@ -5,7 +5,7 @@
     <title>Rotation - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Rotation</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3325">
             <strong>Signature:</strong> unit -&gt; Rotation<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L91-91" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L91-91" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3326">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L104-104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L104-104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3327">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L104-104" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L104-104" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3328">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L99-99" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L99-99" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="3329">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L99-99" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L99-99" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="3330">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L109-109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L109-109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="3331">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L109-109" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L109-109" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="3332">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L118-118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L118-118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -247,10 +248,10 @@
           </code>
           <div class="tip" id="3333">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L117-117" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L117-117" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -265,10 +266,10 @@
           </code>
           <div class="tip" id="3334">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L119-119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L119-119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -287,7 +288,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -350,6 +351,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-scatter.html
+++ b/docs/reference/xplot-plotly-graph-scatter.html
@@ -5,7 +5,7 @@
     <title>Scatter - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Scatter</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3335">
             <strong>Signature:</strong> unit -&gt; Scatter<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1739-1739" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1739-1739" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3336">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1866-1866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1866-1866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3337">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1866-1866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1866-1866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3338">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1832-1832" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1832-1832" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="3339">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1832-1832" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1832-1832" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="3340">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1847-1847" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1847-1847" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="3341">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1847-1847" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1847-1847" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="3342">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1907-1907" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1907-1907" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -248,10 +249,10 @@
           </code>
           <div class="tip" id="3343">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1907-1907" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1907-1907" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="3344">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1903-1903" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1903-1903" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -286,10 +287,10 @@
           </code>
           <div class="tip" id="3345">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1903-1903" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1903-1903" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="3346">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1871-1871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1871-1871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="3347">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1871-1871" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1871-1871" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="3348">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1876-1876" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1876-1876" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="3349">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1876-1876" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1876-1876" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="3350">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1813-1813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1813-1813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="3351">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1813-1813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1813-1813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3352">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1794-1794" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1794-1794" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="3353">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1794-1794" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1794-1794" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="3354">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1861-1861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1861-1861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -492,10 +493,10 @@
           </code>
           <div class="tip" id="3355">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1861-1861" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1861-1861" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +512,10 @@
           </code>
           <div class="tip" id="3356">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1880-1880" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1880-1880" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -530,10 +531,10 @@
           </code>
           <div class="tip" id="3357">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1880-1880" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1880-1880" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -549,10 +550,10 @@
           </code>
           <div class="tip" id="3358">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1857-1857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1857-1857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -570,10 +571,10 @@
           </code>
           <div class="tip" id="3359">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1857-1857" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1857-1857" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="3360">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1799-1799" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1799-1799" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -612,10 +613,10 @@
           </code>
           <div class="tip" id="3361">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1799-1799" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1799-1799" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="3362">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1894-1894" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1894-1894" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="3363">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1894-1894" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1894-1894" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="3364">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1942-1942" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1942-1942" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -696,10 +697,10 @@
           </code>
           <div class="tip" id="3365">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1942-1942" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1942-1942" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="3366">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1969-1969" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1969-1969" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="3367">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1962-1962" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1962-1962" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -753,10 +754,10 @@
           </code>
           <div class="tip" id="3368">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1965-1965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1965-1965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -771,10 +772,10 @@
           </code>
           <div class="tip" id="3369">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1978-1978" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1978-1978" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -789,10 +790,10 @@
           </code>
           <div class="tip" id="3370">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1977-1977" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1977-1977" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -807,10 +808,10 @@
           </code>
           <div class="tip" id="3371">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1970-1970" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1970-1970" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="3372">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1971-1971" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1971-1971" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="3373">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1958-1958" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1958-1958" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="3374">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1954-1954" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1954-1954" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="3375">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1968-1968" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1968-1968" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -897,10 +898,10 @@
           </code>
           <div class="tip" id="3376">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1972-1972" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1972-1972" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -915,10 +916,10 @@
           </code>
           <div class="tip" id="3377">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1967-1967" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1967-1967" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="3378">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1955-1955" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1955-1955" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -951,10 +952,10 @@
           </code>
           <div class="tip" id="3379">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1975-1975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1975-1975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="3380">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1985-1985" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1985-1985" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -987,10 +988,10 @@
           </code>
           <div class="tip" id="3381">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1953-1953" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1953-1953" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="3382">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1959-1959" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1959-1959" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1023,10 +1024,10 @@
           </code>
           <div class="tip" id="3383">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1976-1976" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1976-1976" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1041,10 +1042,10 @@
           </code>
           <div class="tip" id="3384">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1966-1966" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1966-1966" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1059,10 +1060,10 @@
           </code>
           <div class="tip" id="3385">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1974-1974" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1974-1974" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1077,10 +1078,10 @@
           </code>
           <div class="tip" id="3386">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1973-1973" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1973-1973" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1095,10 +1096,10 @@
           </code>
           <div class="tip" id="3387">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1984-1984" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1984-1984" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1113,10 +1114,10 @@
           </code>
           <div class="tip" id="3388">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1983-1983" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1983-1983" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1131,10 +1132,10 @@
           </code>
           <div class="tip" id="3389">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1986-1986" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1986-1986" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1149,10 +1150,10 @@
           </code>
           <div class="tip" id="3390">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1951-1951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1951-1951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1167,10 +1168,10 @@
           </code>
           <div class="tip" id="3391">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1957-1957" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1957-1957" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1185,10 +1186,10 @@
           </code>
           <div class="tip" id="3392">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1952-1952" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1952-1952" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1203,10 +1204,10 @@
           </code>
           <div class="tip" id="3393">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1960-1960" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1960-1960" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1221,10 +1222,10 @@
           </code>
           <div class="tip" id="3394">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1961-1961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1961-1961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1239,10 +1240,10 @@
           </code>
           <div class="tip" id="3395">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1979-1979" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1979-1979" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1257,10 +1258,10 @@
           </code>
           <div class="tip" id="3396">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1981-1981" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1981-1981" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1275,10 +1276,10 @@
           </code>
           <div class="tip" id="3397">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1963-1963" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1963-1963" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="3398">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1964-1964" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1964-1964" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1311,10 +1312,10 @@
           </code>
           <div class="tip" id="3399">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1980-1980" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1980-1980" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1329,10 +1330,10 @@
           </code>
           <div class="tip" id="3400">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1982-1982" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1982-1982" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1347,10 +1348,10 @@
           </code>
           <div class="tip" id="3401">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1789-1789" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1789-1789" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1368,10 +1369,10 @@
           </code>
           <div class="tip" id="3402">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1789-1789" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1789-1789" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1389,10 +1390,10 @@
           </code>
           <div class="tip" id="3403">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1817-1817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1817-1817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1408,10 +1409,10 @@
           </code>
           <div class="tip" id="3404">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1817-1817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1817-1817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1427,10 +1428,10 @@
           </code>
           <div class="tip" id="3405">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1899-1899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1899-1899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1448,10 +1449,10 @@
           </code>
           <div class="tip" id="3406">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1899-1899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1899-1899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1469,10 +1470,10 @@
           </code>
           <div class="tip" id="3407">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1852-1852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1852-1852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1490,10 +1491,10 @@
           </code>
           <div class="tip" id="3408">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1852-1852" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1852-1852" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1511,10 +1512,10 @@
           </code>
           <div class="tip" id="3409">
             <strong>Signature:</strong> unit -&gt; Textfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1889-1889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1889-1889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1530,10 +1531,10 @@
           </code>
           <div class="tip" id="3410">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1889-1889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1889-1889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1549,10 +1550,10 @@
           </code>
           <div class="tip" id="3411">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1885-1885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1885-1885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1570,10 +1571,10 @@
           </code>
           <div class="tip" id="3412">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1885-1885" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1885-1885" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1591,10 +1592,10 @@
           </code>
           <div class="tip" id="3413">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1937-1937" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1937-1937" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1612,10 +1613,10 @@
           </code>
           <div class="tip" id="3414">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1937-1937" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1937-1937" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1633,10 +1634,10 @@
           </code>
           <div class="tip" id="3415">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1932-1932" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1932-1932" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1654,10 +1655,10 @@
           </code>
           <div class="tip" id="3416">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1932-1932" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1932-1932" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1675,10 +1676,10 @@
           </code>
           <div class="tip" id="3417">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1947-1947" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1947-1947" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1696,10 +1697,10 @@
           </code>
           <div class="tip" id="3418">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1947-1947" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1947-1947" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1717,10 +1718,10 @@
           </code>
           <div class="tip" id="3419">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1779-1779" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1779-1779" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1736,10 +1737,10 @@
           </code>
           <div class="tip" id="3420">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1779-1779" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1779-1779" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1755,10 +1756,10 @@
           </code>
           <div class="tip" id="3421">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1808-1808" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1808-1808" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1774,10 +1775,10 @@
           </code>
           <div class="tip" id="3422">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1808-1808" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1808-1808" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1793,10 +1794,10 @@
           </code>
           <div class="tip" id="3423">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1784-1784" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1784-1784" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1814,10 +1815,10 @@
           </code>
           <div class="tip" id="3424">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1784-1784" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1784-1784" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1835,10 +1836,10 @@
           </code>
           <div class="tip" id="3425">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1822-1822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1822-1822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1856,10 +1857,10 @@
           </code>
           <div class="tip" id="3426">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1822-1822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1822-1822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1877,10 +1878,10 @@
           </code>
           <div class="tip" id="3427">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1827-1827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1827-1827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1898,10 +1899,10 @@
           </code>
           <div class="tip" id="3428">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1827-1827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1827-1827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1919,10 +1920,10 @@
           </code>
           <div class="tip" id="3429">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1912-1912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1912-1912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1940,10 +1941,10 @@
           </code>
           <div class="tip" id="3430">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1912-1912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1912-1912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1961,10 +1962,10 @@
           </code>
           <div class="tip" id="3431">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1922-1922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1922-1922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1982,10 +1983,10 @@
           </code>
           <div class="tip" id="3432">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1922-1922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1922-1922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2003,10 +2004,10 @@
           </code>
           <div class="tip" id="3433">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1837-1837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1837-1837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2024,10 +2025,10 @@
           </code>
           <div class="tip" id="3434">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1837-1837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1837-1837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2045,10 +2046,10 @@
           </code>
           <div class="tip" id="3435">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1842-1842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1842-1842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2066,10 +2067,10 @@
           </code>
           <div class="tip" id="3436">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1842-1842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1842-1842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2087,10 +2088,10 @@
           </code>
           <div class="tip" id="3437">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1917-1917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1917-1917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2108,10 +2109,10 @@
           </code>
           <div class="tip" id="3438">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1917-1917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1917-1917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2129,10 +2130,10 @@
           </code>
           <div class="tip" id="3439">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1927-1927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1927-1927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2150,10 +2151,10 @@
           </code>
           <div class="tip" id="3440">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1927-1927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1927-1927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2175,7 +2176,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2238,6 +2239,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-scatter3d.html
+++ b/docs/reference/xplot-plotly-graph-scatter3d.html
@@ -5,7 +5,7 @@
     <title>Scatter3d - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Scatter3d</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3441">
             <strong>Signature:</strong> unit -&gt; Scatter3d<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4216-4216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4216-4216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3442">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4348-4348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4348-4348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3443">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4348-4348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4348-4348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3444">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4352-4352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4352-4352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="3445">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4352-4352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4352-4352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="3446">
             <strong>Signature:</strong> unit -&gt; Error_z<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4356-4356" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4356-4356" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="3447">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4356-4356" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4356-4356" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="3448">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4284-4284" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4284-4284" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -238,10 +239,10 @@
           </code>
           <div class="tip" id="3449">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4284-4284" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4284-4284" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -259,10 +260,10 @@
           </code>
           <div class="tip" id="3450">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4265-4265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4265-4265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -280,10 +281,10 @@
           </code>
           <div class="tip" id="3451">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4265-4265" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4265-4265" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -301,10 +302,10 @@
           </code>
           <div class="tip" id="3452">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4331-4331" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4331-4331" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -320,10 +321,10 @@
           </code>
           <div class="tip" id="3453">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4331-4331" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4331-4331" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -339,10 +340,10 @@
           </code>
           <div class="tip" id="3454">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4335-4335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4335-4335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -358,10 +359,10 @@
           </code>
           <div class="tip" id="3455">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4335-4335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4335-4335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -377,10 +378,10 @@
           </code>
           <div class="tip" id="3456">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4313-4313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4313-4313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -398,10 +399,10 @@
           </code>
           <div class="tip" id="3457">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4313-4313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4313-4313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -419,10 +420,10 @@
           </code>
           <div class="tip" id="3458">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4270-4270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4270-4270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -440,10 +441,10 @@
           </code>
           <div class="tip" id="3459">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4270-4270" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4270-4270" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="3460">
             <strong>Signature:</strong> unit -&gt; Projection<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4327-4327" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4327-4327" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -480,10 +481,10 @@
           </code>
           <div class="tip" id="3461">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4327-4327" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4327-4327" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -499,10 +500,10 @@
           </code>
           <div class="tip" id="3462">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4361-4361" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4361-4361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -520,10 +521,10 @@
           </code>
           <div class="tip" id="3463">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4361-4361" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4361-4361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -541,10 +542,10 @@
           </code>
           <div class="tip" id="3464">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4411-4411" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4411-4411" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -559,10 +560,10 @@
           </code>
           <div class="tip" id="3465">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4412-4412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4412-4412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -577,10 +578,10 @@
           </code>
           <div class="tip" id="3466">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4413-4413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4413-4413" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -595,10 +596,10 @@
           </code>
           <div class="tip" id="3467">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4397-4397" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4397-4397" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -613,10 +614,10 @@
           </code>
           <div class="tip" id="3468">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4393-4393" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4393-4393" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -631,10 +632,10 @@
           </code>
           <div class="tip" id="3469">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4407-4407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4407-4407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -649,10 +650,10 @@
           </code>
           <div class="tip" id="3470">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4408-4408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4408-4408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -667,10 +668,10 @@
           </code>
           <div class="tip" id="3471">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4403-4403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4403-4403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -685,10 +686,10 @@
           </code>
           <div class="tip" id="3472">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4394-4394" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4394-4394" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -703,10 +704,10 @@
           </code>
           <div class="tip" id="3473">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4406-4406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4406-4406" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -721,10 +722,10 @@
           </code>
           <div class="tip" id="3474">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4414-4414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4414-4414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -739,10 +740,10 @@
           </code>
           <div class="tip" id="3475">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4392-4392" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4392-4392" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -757,10 +758,10 @@
           </code>
           <div class="tip" id="3476">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4398-4398" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4398-4398" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -775,10 +776,10 @@
           </code>
           <div class="tip" id="3477">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4404-4404" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4404-4404" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -793,10 +794,10 @@
           </code>
           <div class="tip" id="3478">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4405-4405" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4405-4405" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -811,10 +812,10 @@
           </code>
           <div class="tip" id="3479">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4402-4402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4402-4402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -829,10 +830,10 @@
           </code>
           <div class="tip" id="3480">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4410-4410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4410-4410" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -847,10 +848,10 @@
           </code>
           <div class="tip" id="3481">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4409-4409" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4409-4409" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -865,10 +866,10 @@
           </code>
           <div class="tip" id="3482">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4419-4419" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4419-4419" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -883,10 +884,10 @@
           </code>
           <div class="tip" id="3483">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4418-4418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4418-4418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -901,10 +902,10 @@
           </code>
           <div class="tip" id="3484">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4390-4390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4390-4390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -919,10 +920,10 @@
           </code>
           <div class="tip" id="3485">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4396-4396" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4396-4396" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -937,10 +938,10 @@
           </code>
           <div class="tip" id="3486">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4391-4391" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4391-4391" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -955,10 +956,10 @@
           </code>
           <div class="tip" id="3487">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4399-4399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4399-4399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -973,10 +974,10 @@
           </code>
           <div class="tip" id="3488">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4415-4415" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4415-4415" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -991,10 +992,10 @@
           </code>
           <div class="tip" id="3489">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4400-4400" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4400-4400" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1009,10 +1010,10 @@
           </code>
           <div class="tip" id="3490">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4416-4416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4416-4416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1027,10 +1028,10 @@
           </code>
           <div class="tip" id="3491">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4401-4401" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4401-4401" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1045,10 +1046,10 @@
           </code>
           <div class="tip" id="3492">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4417-4417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4417-4417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1063,10 +1064,10 @@
           </code>
           <div class="tip" id="3493">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4260-4260" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4260-4260" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1084,10 +1085,10 @@
           </code>
           <div class="tip" id="3494">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4260-4260" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4260-4260" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1105,10 +1106,10 @@
           </code>
           <div class="tip" id="3495">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4288-4288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4288-4288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1124,10 +1125,10 @@
           </code>
           <div class="tip" id="3496">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4288-4288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4288-4288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1143,10 +1144,10 @@
           </code>
           <div class="tip" id="3497">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4318-4318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4318-4318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1164,10 +1165,10 @@
           </code>
           <div class="tip" id="3498">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4318-4318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4318-4318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1185,10 +1186,10 @@
           </code>
           <div class="tip" id="3499">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4323-4323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4323-4323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1206,10 +1207,10 @@
           </code>
           <div class="tip" id="3500">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4323-4323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4323-4323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1227,10 +1228,10 @@
           </code>
           <div class="tip" id="3501">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4308-4308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4308-4308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1248,10 +1249,10 @@
           </code>
           <div class="tip" id="3502">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4308-4308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4308-4308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1269,10 +1270,10 @@
           </code>
           <div class="tip" id="3503">
             <strong>Signature:</strong> unit -&gt; Textfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4344-4344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4344-4344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1288,10 +1289,10 @@
           </code>
           <div class="tip" id="3504">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4344-4344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4344-4344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1307,10 +1308,10 @@
           </code>
           <div class="tip" id="3505">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4340-4340" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4340-4340" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1328,10 +1329,10 @@
           </code>
           <div class="tip" id="3506">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4340-4340" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4340-4340" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1349,10 +1350,10 @@
           </code>
           <div class="tip" id="3507">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4386-4386" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4386-4386" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1370,10 +1371,10 @@
           </code>
           <div class="tip" id="3508">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4386-4386" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4386-4386" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1391,10 +1392,10 @@
           </code>
           <div class="tip" id="3509">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4381-4381" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4381-4381" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1412,10 +1413,10 @@
           </code>
           <div class="tip" id="3510">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4381-4381" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4381-4381" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1433,10 +1434,10 @@
           </code>
           <div class="tip" id="3511">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4250-4250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4250-4250" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1452,10 +1453,10 @@
           </code>
           <div class="tip" id="3512">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4250-4250" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4250-4250" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1471,10 +1472,10 @@
           </code>
           <div class="tip" id="3513">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4279-4279" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4279-4279" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1492,10 +1493,10 @@
           </code>
           <div class="tip" id="3514">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4279-4279" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4279-4279" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1513,10 +1514,10 @@
           </code>
           <div class="tip" id="3515">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4255-4255" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4255-4255" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1534,10 +1535,10 @@
           </code>
           <div class="tip" id="3516">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4255-4255" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4255-4255" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1555,10 +1556,10 @@
           </code>
           <div class="tip" id="3517">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4293-4293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4293-4293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1576,10 +1577,10 @@
           </code>
           <div class="tip" id="3518">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4293-4293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4293-4293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1597,10 +1598,10 @@
           </code>
           <div class="tip" id="3519">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4366-4366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4366-4366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1618,10 +1619,10 @@
           </code>
           <div class="tip" id="3520">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4366-4366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4366-4366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1639,10 +1640,10 @@
           </code>
           <div class="tip" id="3521">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4298-4298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4298-4298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1660,10 +1661,10 @@
           </code>
           <div class="tip" id="3522">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4298-4298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4298-4298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1681,10 +1682,10 @@
           </code>
           <div class="tip" id="3523">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4371-4371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4371-4371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1702,10 +1703,10 @@
           </code>
           <div class="tip" id="3524">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4371-4371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4371-4371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1723,10 +1724,10 @@
           </code>
           <div class="tip" id="3525">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4303-4303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4303-4303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1744,10 +1745,10 @@
           </code>
           <div class="tip" id="3526">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4303-4303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4303-4303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1765,10 +1766,10 @@
           </code>
           <div class="tip" id="3527">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4376-4376" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4376-4376" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1786,10 +1787,10 @@
           </code>
           <div class="tip" id="3528">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4376-4376" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4376-4376" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1811,7 +1812,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1874,6 +1875,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-scattergeo.html
+++ b/docs/reference/xplot-plotly-graph-scattergeo.html
@@ -5,7 +5,7 @@
     <title>Scattergeo - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Scattergeo</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3529">
             <strong>Signature:</strong> unit -&gt; Scattergeo<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4878-4878" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4878-4878" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3530">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4997-4997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4997-4997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3531">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4997-4997" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4997-4997" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3532">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4941-4941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4941-4941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="3533">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4941-4941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4941-4941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="3534">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4955-4955" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4955-4955" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="3535">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4955-4955" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4955-4955" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="3536">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5007-5007" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5007-5007" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="3537">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5007-5007" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5007-5007" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="3538">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4922-4922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4922-4922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="3539">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4922-4922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4922-4922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="3540">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4979-4979" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4979-4979" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="3541">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4979-4979" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4979-4979" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -351,10 +352,10 @@
           </code>
           <div class="tip" id="3542">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4965-4965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4965-4965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="3543">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4965-4965" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4965-4965" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="3544">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4960-4960" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4960-4960" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -414,10 +415,10 @@
           </code>
           <div class="tip" id="3545">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4960-4960" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4960-4960" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -435,10 +436,10 @@
           </code>
           <div class="tip" id="3546">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5012-5012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5012-5012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -456,10 +457,10 @@
           </code>
           <div class="tip" id="3547">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5012-5012" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5012-5012" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -477,10 +478,10 @@
           </code>
           <div class="tip" id="3548">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4950-4950" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4950-4950" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -498,10 +499,10 @@
           </code>
           <div class="tip" id="3549">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4950-4950" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4950-4950" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -519,10 +520,10 @@
           </code>
           <div class="tip" id="3550">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5002-5002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5002-5002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -540,10 +541,10 @@
           </code>
           <div class="tip" id="3551">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5002-5002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5002-5002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -561,10 +562,10 @@
           </code>
           <div class="tip" id="3552">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4983-4983" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4983-4983" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -580,10 +581,10 @@
           </code>
           <div class="tip" id="3553">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4983-4983" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4983-4983" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="3554">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4970-4970" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4970-4970" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -620,10 +621,10 @@
           </code>
           <div class="tip" id="3555">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4970-4970" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4970-4970" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="3556">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4927-4927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4927-4927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="3557">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4927-4927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4927-4927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="3558">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5045-5045" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5045-5045" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -701,10 +702,10 @@
           </code>
           <div class="tip" id="3559">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5033-5033" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5033-5033" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -719,10 +720,10 @@
           </code>
           <div class="tip" id="3560">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5036-5036" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5036-5036" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -737,10 +738,10 @@
           </code>
           <div class="tip" id="3561">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5047-5047" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5047-5047" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -755,10 +756,10 @@
           </code>
           <div class="tip" id="3562">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5029-5029" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5029-5029" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -773,10 +774,10 @@
           </code>
           <div class="tip" id="3563">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5041-5041" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5041-5041" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -791,10 +792,10 @@
           </code>
           <div class="tip" id="3564">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5038-5038" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5038-5038" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -809,10 +810,10 @@
           </code>
           <div class="tip" id="3565">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5037-5037" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5037-5037" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -827,10 +828,10 @@
           </code>
           <div class="tip" id="3566">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5048-5048" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5048-5048" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -845,10 +846,10 @@
           </code>
           <div class="tip" id="3567">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5035-5035" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5035-5035" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -863,10 +864,10 @@
           </code>
           <div class="tip" id="3568">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5046-5046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5046-5046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -881,10 +882,10 @@
           </code>
           <div class="tip" id="3569">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5042-5042" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5042-5042" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -899,10 +900,10 @@
           </code>
           <div class="tip" id="3570">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5039-5039" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5039-5039" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -917,10 +918,10 @@
           </code>
           <div class="tip" id="3571">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5030-5030" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5030-5030" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -935,10 +936,10 @@
           </code>
           <div class="tip" id="3572">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5028-5028" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5028-5028" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -953,10 +954,10 @@
           </code>
           <div class="tip" id="3573">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5034-5034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5034-5034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -971,10 +972,10 @@
           </code>
           <div class="tip" id="3574">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5040-5040" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5040-5040" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -989,10 +990,10 @@
           </code>
           <div class="tip" id="3575">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5043-5043" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5043-5043" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,10 +1008,10 @@
           </code>
           <div class="tip" id="3576">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5044-5044" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5044-5044" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1025,10 +1026,10 @@
           </code>
           <div class="tip" id="3577">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5050-5050" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5050-5050" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1043,10 +1044,10 @@
           </code>
           <div class="tip" id="3578">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5049-5049" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5049-5049" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1061,10 +1062,10 @@
           </code>
           <div class="tip" id="3579">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5026-5026" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5026-5026" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1079,10 +1080,10 @@
           </code>
           <div class="tip" id="3580">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5032-5032" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5032-5032" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1097,10 +1098,10 @@
           </code>
           <div class="tip" id="3581">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5027-5027" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5027-5027" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1115,10 +1116,10 @@
           </code>
           <div class="tip" id="3582">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4917-4917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4917-4917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1136,10 +1137,10 @@
           </code>
           <div class="tip" id="3583">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4917-4917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4917-4917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1157,10 +1158,10 @@
           </code>
           <div class="tip" id="3584">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4945-4945" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4945-4945" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1176,10 +1177,10 @@
           </code>
           <div class="tip" id="3585">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4945-4945" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4945-4945" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1195,10 +1196,10 @@
           </code>
           <div class="tip" id="3586">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4975-4975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4975-4975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1216,10 +1217,10 @@
           </code>
           <div class="tip" id="3587">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4975-4975" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4975-4975" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1237,10 +1238,10 @@
           </code>
           <div class="tip" id="3588">
             <strong>Signature:</strong> unit -&gt; Textfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4987-4987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4987-4987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1256,10 +1257,10 @@
           </code>
           <div class="tip" id="3589">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4987-4987" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4987-4987" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1275,10 +1276,10 @@
           </code>
           <div class="tip" id="3590">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4992-4992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4992-4992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1296,10 +1297,10 @@
           </code>
           <div class="tip" id="3591">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4992-4992" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4992-4992" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1317,10 +1318,10 @@
           </code>
           <div class="tip" id="3592">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5022-5022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5022-5022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1338,10 +1339,10 @@
           </code>
           <div class="tip" id="3593">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5022-5022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5022-5022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1359,10 +1360,10 @@
           </code>
           <div class="tip" id="3594">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5017-5017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5017-5017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1380,10 +1381,10 @@
           </code>
           <div class="tip" id="3595">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5017-5017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5017-5017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1401,10 +1402,10 @@
           </code>
           <div class="tip" id="3596">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4907-4907" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4907-4907" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1420,10 +1421,10 @@
           </code>
           <div class="tip" id="3597">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4907-4907" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4907-4907" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1439,10 +1440,10 @@
           </code>
           <div class="tip" id="3598">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4936-4936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4936-4936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1460,10 +1461,10 @@
           </code>
           <div class="tip" id="3599">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4936-4936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4936-4936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1481,10 +1482,10 @@
           </code>
           <div class="tip" id="3600">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4912-4912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4912-4912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1502,10 +1503,10 @@
           </code>
           <div class="tip" id="3601">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4912-4912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4912-4912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1527,7 +1528,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1590,6 +1591,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-scattergl.html
+++ b/docs/reference/xplot-plotly-graph-scattergl.html
@@ -5,7 +5,7 @@
     <title>Scattergl - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Scattergl</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3602">
             <strong>Signature:</strong> unit -&gt; Scattergl<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5234-5234" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5234-5234" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3603">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5319-5319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5319-5319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3604">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5319-5319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5319-5319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3605">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5334-5334" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5334-5334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="3606">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5334-5334" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5334-5334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="3607">
             <strong>Signature:</strong> unit -&gt; Error_x<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5366-5366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5366-5366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -206,10 +207,10 @@
           </code>
           <div class="tip" id="3608">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5366-5366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5366-5366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3609">
             <strong>Signature:</strong> unit -&gt; Error_y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5370-5370" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5370-5370" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="3610">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5370-5370" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5370-5370" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="3611">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5357-5357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5357-5357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -284,10 +285,10 @@
           </code>
           <div class="tip" id="3612">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5357-5357" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5357-5357" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="3613">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5362-5362" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5362-5362" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="3614">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5362-5362" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5362-5362" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="3615">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5300-5300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5300-5300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="3616">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5300-5300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5300-5300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="3617">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5281-5281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5281-5281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="3618">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5281-5281" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5281-5281" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3619">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5348-5348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5348-5348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -450,10 +451,10 @@
           </code>
           <div class="tip" id="3620">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5348-5348" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5348-5348" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -469,10 +470,10 @@
           </code>
           <div class="tip" id="3621">
             <strong>Signature:</strong> unit -&gt; Marker<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5352-5352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5352-5352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -488,10 +489,10 @@
           </code>
           <div class="tip" id="3622">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5352-5352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5352-5352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -507,10 +508,10 @@
           </code>
           <div class="tip" id="3623">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5344-5344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5344-5344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -528,10 +529,10 @@
           </code>
           <div class="tip" id="3624">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5344-5344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5344-5344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -549,10 +550,10 @@
           </code>
           <div class="tip" id="3625">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5286-5286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5286-5286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -570,10 +571,10 @@
           </code>
           <div class="tip" id="3626">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5286-5286" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5286-5286" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="3627">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5410-5410" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5410-5410" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -609,10 +610,10 @@
           </code>
           <div class="tip" id="3628">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5413-5413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5413-5413" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -627,10 +628,10 @@
           </code>
           <div class="tip" id="3629">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5420-5420" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5420-5420" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -645,10 +646,10 @@
           </code>
           <div class="tip" id="3630">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5421-5421" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5421-5421" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -663,10 +664,10 @@
           </code>
           <div class="tip" id="3631">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5418-5418" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5418-5418" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -681,10 +682,10 @@
           </code>
           <div class="tip" id="3632">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5419-5419" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5419-5419" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -699,10 +700,10 @@
           </code>
           <div class="tip" id="3633">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5406-5406" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5406-5406" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="3634">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5402-5402" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5402-5402" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="3635">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5416-5416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5416-5416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -753,10 +754,10 @@
           </code>
           <div class="tip" id="3636">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5417-5417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5417-5417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -771,10 +772,10 @@
           </code>
           <div class="tip" id="3637">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5415-5415" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5415-5415" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -789,10 +790,10 @@
           </code>
           <div class="tip" id="3638">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5403-5403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5403-5403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -807,10 +808,10 @@
           </code>
           <div class="tip" id="3639">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5401-5401" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5401-5401" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -825,10 +826,10 @@
           </code>
           <div class="tip" id="3640">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5407-5407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5407-5407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -843,10 +844,10 @@
           </code>
           <div class="tip" id="3641">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5414-5414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5414-5414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="3642">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5426-5426" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5426-5426" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -879,10 +880,10 @@
           </code>
           <div class="tip" id="3643">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5399-5399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5399-5399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -897,10 +898,10 @@
           </code>
           <div class="tip" id="3644">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5405-5405" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5405-5405" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -915,10 +916,10 @@
           </code>
           <div class="tip" id="3645">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5400-5400" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5400-5400" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -933,10 +934,10 @@
           </code>
           <div class="tip" id="3646">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5408-5408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5408-5408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -951,10 +952,10 @@
           </code>
           <div class="tip" id="3647">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5409-5409" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5409-5409" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -969,10 +970,10 @@
           </code>
           <div class="tip" id="3648">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5422-5422" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5422-5422" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -987,10 +988,10 @@
           </code>
           <div class="tip" id="3649">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5424-5424" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5424-5424" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1005,10 +1006,10 @@
           </code>
           <div class="tip" id="3650">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5411-5411" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5411-5411" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1023,10 +1024,10 @@
           </code>
           <div class="tip" id="3651">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5412-5412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5412-5412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1041,10 +1042,10 @@
           </code>
           <div class="tip" id="3652">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5423-5423" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5423-5423" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1059,10 +1060,10 @@
           </code>
           <div class="tip" id="3653">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5425-5425" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5425-5425" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1077,10 +1078,10 @@
           </code>
           <div class="tip" id="3654">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5276-5276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5276-5276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1098,10 +1099,10 @@
           </code>
           <div class="tip" id="3655">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5276-5276" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5276-5276" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1119,10 +1120,10 @@
           </code>
           <div class="tip" id="3656">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5304-5304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5304-5304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1138,10 +1139,10 @@
           </code>
           <div class="tip" id="3657">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5304-5304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5304-5304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1157,10 +1158,10 @@
           </code>
           <div class="tip" id="3658">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5339-5339" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5339-5339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1178,10 +1179,10 @@
           </code>
           <div class="tip" id="3659">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5339-5339" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5339-5339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1199,10 +1200,10 @@
           </code>
           <div class="tip" id="3660">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5395-5395" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5395-5395" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1220,10 +1221,10 @@
           </code>
           <div class="tip" id="3661">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5395-5395" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5395-5395" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1241,10 +1242,10 @@
           </code>
           <div class="tip" id="3662">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5266-5266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5266-5266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1260,10 +1261,10 @@
           </code>
           <div class="tip" id="3663">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5266-5266" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5266-5266" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1279,10 +1280,10 @@
           </code>
           <div class="tip" id="3664">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5295-5295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5295-5295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1300,10 +1301,10 @@
           </code>
           <div class="tip" id="3665">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5295-5295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5295-5295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1321,10 +1322,10 @@
           </code>
           <div class="tip" id="3666">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5271-5271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5271-5271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1342,10 +1343,10 @@
           </code>
           <div class="tip" id="3667">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5271-5271" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5271-5271" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1363,10 +1364,10 @@
           </code>
           <div class="tip" id="3668">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5309-5309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5309-5309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1384,10 +1385,10 @@
           </code>
           <div class="tip" id="3669">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5309-5309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5309-5309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1405,10 +1406,10 @@
           </code>
           <div class="tip" id="3670">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5314-5314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5314-5314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1426,10 +1427,10 @@
           </code>
           <div class="tip" id="3671">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5314-5314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5314-5314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1447,10 +1448,10 @@
           </code>
           <div class="tip" id="3672">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5375-5375" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5375-5375" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1468,10 +1469,10 @@
           </code>
           <div class="tip" id="3673">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5375-5375" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5375-5375" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1489,10 +1490,10 @@
           </code>
           <div class="tip" id="3674">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5385-5385" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5385-5385" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1510,10 +1511,10 @@
           </code>
           <div class="tip" id="3675">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5385-5385" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5385-5385" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1531,10 +1532,10 @@
           </code>
           <div class="tip" id="3676">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5324-5324" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5324-5324" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1552,10 +1553,10 @@
           </code>
           <div class="tip" id="3677">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5324-5324" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5324-5324" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1573,10 +1574,10 @@
           </code>
           <div class="tip" id="3678">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5329-5329" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5329-5329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1594,10 +1595,10 @@
           </code>
           <div class="tip" id="3679">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5329-5329" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5329-5329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1615,10 +1616,10 @@
           </code>
           <div class="tip" id="3680">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5380-5380" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5380-5380" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1636,10 +1637,10 @@
           </code>
           <div class="tip" id="3681">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5380-5380" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5380-5380" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1657,10 +1658,10 @@
           </code>
           <div class="tip" id="3682">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5390-5390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5390-5390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1678,10 +1679,10 @@
           </code>
           <div class="tip" id="3683">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5390-5390" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5390-5390" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1703,7 +1704,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1766,6 +1767,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-scene.html
+++ b/docs/reference/xplot-plotly-graph-scene.html
@@ -5,7 +5,7 @@
     <title>Scene - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Scene</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3684">
             <strong>Signature:</strong> unit -&gt; Scene<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6853-6853" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6853-6853" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3685">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6899-6899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6899-6899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3686">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6899-6899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6899-6899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3687">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6879-6879" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6879-6879" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3688">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6879-6879" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6879-6879" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3689">
             <strong>Signature:</strong> unit -&gt; Aspectratio<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6883-6883" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6883-6883" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -202,10 +203,10 @@
           </code>
           <div class="tip" id="3690">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6883-6883" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6883-6883" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -221,10 +222,10 @@
           </code>
           <div class="tip" id="3691">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6866-6866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6866-6866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -240,10 +241,10 @@
           </code>
           <div class="tip" id="3692">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6866-6866" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6866-6866" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -259,10 +260,10 @@
           </code>
           <div class="tip" id="3693">
             <strong>Signature:</strong> unit -&gt; Camera<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6870-6870" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6870-6870" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -278,10 +279,10 @@
           </code>
           <div class="tip" id="3694">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6870-6870" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6870-6870" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="3695">
             <strong>Signature:</strong> unit -&gt; Domain<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6874-6874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6874-6874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="3696">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6874-6874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6874-6874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="3697">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6915-6915" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6915-6915" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -353,10 +354,10 @@
           </code>
           <div class="tip" id="3698">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6910-6910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6910-6910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -371,10 +372,10 @@
           </code>
           <div class="tip" id="3699">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6911-6911" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6911-6911" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="3700">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6907-6907" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6907-6907" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -407,10 +408,10 @@
           </code>
           <div class="tip" id="3701">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6908-6908" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6908-6908" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -425,10 +426,10 @@
           </code>
           <div class="tip" id="3702">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6909-6909" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6909-6909" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -443,10 +444,10 @@
           </code>
           <div class="tip" id="3703">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6912-6912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6912-6912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="3704">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6913-6913" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6913-6913" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -479,10 +480,10 @@
           </code>
           <div class="tip" id="3705">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6914-6914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6914-6914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -497,10 +498,10 @@
           </code>
           <div class="tip" id="3706">
             <strong>Signature:</strong> unit -&gt; Xaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6887-6887" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6887-6887" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -516,10 +517,10 @@
           </code>
           <div class="tip" id="3707">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6887-6887" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6887-6887" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -535,10 +536,10 @@
           </code>
           <div class="tip" id="3708">
             <strong>Signature:</strong> unit -&gt; Yaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6891-6891" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6891-6891" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -554,10 +555,10 @@
           </code>
           <div class="tip" id="3709">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6891-6891" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6891-6891" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -573,10 +574,10 @@
           </code>
           <div class="tip" id="3710">
             <strong>Signature:</strong> unit -&gt; Zaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6895-6895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6895-6895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -592,10 +593,10 @@
           </code>
           <div class="tip" id="3711">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6895-6895" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6895-6895" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -615,7 +616,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -678,6 +679,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-shape.html
+++ b/docs/reference/xplot-plotly-graph-shape.html
@@ -5,7 +5,7 @@
     <title>Shape - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Shape</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3712">
             <strong>Signature:</strong> unit -&gt; Shape<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7489-7489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7489-7489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3713">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7554-7554" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7554-7554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3714">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7554-7554" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7554-7554" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3715">
             <strong>Signature:</strong> unit -&gt; Line<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7549-7549" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7549-7549" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="3716">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7549-7549" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7549-7549" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3717">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7545-7545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7545-7545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="3718">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7545-7545" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7545-7545" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3719">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7540-7540" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7540-7540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -246,10 +247,10 @@
           </code>
           <div class="tip" id="3720">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7540-7540" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7540-7540" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -267,10 +268,10 @@
           </code>
           <div class="tip" id="3721">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7572-7572" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7572-7572" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -285,10 +286,10 @@
           </code>
           <div class="tip" id="3722">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7571-7571" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7571-7571" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -303,10 +304,10 @@
           </code>
           <div class="tip" id="3723">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7570-7570" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7570-7570" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -321,10 +322,10 @@
           </code>
           <div class="tip" id="3724">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7569-7569" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7569-7569" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -339,10 +340,10 @@
           </code>
           <div class="tip" id="3725">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7562-7562" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7562-7562" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -357,10 +358,10 @@
           </code>
           <div class="tip" id="3726">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7564-7564" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7564-7564" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -375,10 +376,10 @@
           </code>
           <div class="tip" id="3727">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7565-7565" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7565-7565" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -393,10 +394,10 @@
           </code>
           <div class="tip" id="3728">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7563-7563" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7563-7563" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -411,10 +412,10 @@
           </code>
           <div class="tip" id="3729">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7567-7567" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7567-7567" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -429,10 +430,10 @@
           </code>
           <div class="tip" id="3730">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7568-7568" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7568-7568" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -447,10 +448,10 @@
           </code>
           <div class="tip" id="3731">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7566-7566" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7566-7566" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -465,10 +466,10 @@
           </code>
           <div class="tip" id="3732">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7505-7505" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7505-7505" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -486,10 +487,10 @@
           </code>
           <div class="tip" id="3733">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7505-7505" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7505-7505" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -507,10 +508,10 @@
           </code>
           <div class="tip" id="3734">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7515-7515" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7515-7515" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -528,10 +529,10 @@
           </code>
           <div class="tip" id="3735">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7515-7515" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7515-7515" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -549,10 +550,10 @@
           </code>
           <div class="tip" id="3736">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7520-7520" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7520-7520" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -570,10 +571,10 @@
           </code>
           <div class="tip" id="3737">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7520-7520" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7520-7520" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +592,10 @@
           </code>
           <div class="tip" id="3738">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7510-7510" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7510-7510" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -612,10 +613,10 @@
           </code>
           <div class="tip" id="3739">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7510-7510" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7510-7510" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="3740">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7530-7530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7530-7530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -654,10 +655,10 @@
           </code>
           <div class="tip" id="3741">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7530-7530" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7530-7530" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -675,10 +676,10 @@
           </code>
           <div class="tip" id="3742">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7535-7535" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7535-7535" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -696,10 +697,10 @@
           </code>
           <div class="tip" id="3743">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7535-7535" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7535-7535" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -717,10 +718,10 @@
           </code>
           <div class="tip" id="3744">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7525-7525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7525-7525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -738,10 +739,10 @@
           </code>
           <div class="tip" id="3745">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7525-7525" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7525-7525" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -763,7 +764,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -826,6 +827,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-shapes.html
+++ b/docs/reference/xplot-plotly-graph-shapes.html
@@ -5,7 +5,7 @@
     <title>Shapes - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Shapes</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3746">
             <strong>Signature:</strong> unit -&gt; Shapes<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7611-7611" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7611-7611" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3747">
             <strong>Signature:</strong> unit -&gt; Items<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7616-7616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7616-7616" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3748">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7616-7616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7616-7616" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3749">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7624-7624" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L7624-7624" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,7 +164,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -226,6 +227,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-stream.html
+++ b/docs/reference/xplot-plotly-graph-stream.html
@@ -5,7 +5,7 @@
     <title>Stream - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Stream</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3750">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1715-1715" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1715-1715" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3751">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1727-1727" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1727-1727" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3752">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1727-1727" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1727-1727" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3753">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1736-1736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1736-1736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,10 +164,10 @@
           </code>
           <div class="tip" id="3754">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1735-1735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1735-1735" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -181,10 +182,10 @@
           </code>
           <div class="tip" id="3755">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1722-1722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1722-1722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -202,10 +203,10 @@
           </code>
           <div class="tip" id="3756">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1722-1722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1722-1722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -227,7 +228,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -290,6 +291,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-surface.html
+++ b/docs/reference/xplot-plotly-graph-surface.html
@@ -5,7 +5,7 @@
     <title>Surface - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Surface</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3757">
             <strong>Signature:</strong> unit -&gt; Surface<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4423-4423" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4423-4423" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3758">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4538-4538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4538-4538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3759">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4538-4538" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4538-4538" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3760">
             <strong>Signature:</strong> unit -&gt; Colorbar<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4564-4564" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4564-4564" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -164,10 +165,10 @@
           </code>
           <div class="tip" id="3761">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4564-4564" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4564-4564" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3762">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4533-4533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4533-4533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="3763">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4533-4533" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4533-4533" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3764">
             <strong>Signature:</strong> unit -&gt; Contours<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4552-4552" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4552-4552" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="3765">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4552-4552" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4552-4552" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="3766">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4556-4556" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4556-4556" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -282,10 +283,10 @@
           </code>
           <div class="tip" id="3767">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4556-4556" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4556-4556" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -301,10 +302,10 @@
           </code>
           <div class="tip" id="3768">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4489-4489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4489-4489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -322,10 +323,10 @@
           </code>
           <div class="tip" id="3769">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4489-4489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4489-4489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -343,10 +344,10 @@
           </code>
           <div class="tip" id="3770">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4471-4471" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4471-4471" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -364,10 +365,10 @@
           </code>
           <div class="tip" id="3771">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4471-4471" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4471-4471" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -385,10 +386,10 @@
           </code>
           <div class="tip" id="3772">
             <strong>Signature:</strong> unit -&gt; Lighting<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4560-4560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4560-4560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -404,10 +405,10 @@
           </code>
           <div class="tip" id="3773">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4560-4560" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4560-4560" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -423,10 +424,10 @@
           </code>
           <div class="tip" id="3774">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4475-4475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4475-4475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -442,10 +443,10 @@
           </code>
           <div class="tip" id="3775">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4475-4475" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4475-4475" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -461,10 +462,10 @@
           </code>
           <div class="tip" id="3776">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4543-4543" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4543-4543" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -482,10 +483,10 @@
           </code>
           <div class="tip" id="3777">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4543-4543" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4543-4543" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -503,10 +504,10 @@
           </code>
           <div class="tip" id="3778">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4569-4569" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4569-4569" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -524,10 +525,10 @@
           </code>
           <div class="tip" id="3779">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4569-4569" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4569-4569" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -545,10 +546,10 @@
           </code>
           <div class="tip" id="3780">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4610-4610" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4610-4610" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -563,10 +564,10 @@
           </code>
           <div class="tip" id="3781">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4616-4616" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4616-4616" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -581,10 +582,10 @@
           </code>
           <div class="tip" id="3782">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4609-4609" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4609-4609" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="3783">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4613-4613" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4613-4613" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -617,10 +618,10 @@
           </code>
           <div class="tip" id="3784">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4614-4614" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4614-4614" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -635,10 +636,10 @@
           </code>
           <div class="tip" id="3785">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4600-4600" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4600-4600" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -653,10 +654,10 @@
           </code>
           <div class="tip" id="3786">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4596-4596" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4596-4596" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -671,10 +672,10 @@
           </code>
           <div class="tip" id="3787">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4615-4615" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4615-4615" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -689,10 +690,10 @@
           </code>
           <div class="tip" id="3788">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4597-4597" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4597-4597" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -707,10 +708,10 @@
           </code>
           <div class="tip" id="3789">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4611-4611" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4611-4611" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="3790">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4617-4617" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4617-4617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -743,10 +744,10 @@
           </code>
           <div class="tip" id="3791">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4595-4595" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4595-4595" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -761,10 +762,10 @@
           </code>
           <div class="tip" id="3792">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4612-4612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4612-4612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -779,10 +780,10 @@
           </code>
           <div class="tip" id="3793">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4601-4601" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4601-4601" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -797,10 +798,10 @@
           </code>
           <div class="tip" id="3794">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4605-4605" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4605-4605" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -815,10 +816,10 @@
           </code>
           <div class="tip" id="3795">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4621-4621" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4621-4621" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -833,10 +834,10 @@
           </code>
           <div class="tip" id="3796">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4593-4593" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4593-4593" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -851,10 +852,10 @@
           </code>
           <div class="tip" id="3797">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4599-4599" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4599-4599" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -869,10 +870,10 @@
           </code>
           <div class="tip" id="3798">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4594-4594" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4594-4594" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -887,10 +888,10 @@
           </code>
           <div class="tip" id="3799">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4603-4603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4603-4603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -905,10 +906,10 @@
           </code>
           <div class="tip" id="3800">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4619-4619" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4619-4619" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -923,10 +924,10 @@
           </code>
           <div class="tip" id="3801">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4604-4604" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4604-4604" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -941,10 +942,10 @@
           </code>
           <div class="tip" id="3802">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4620-4620" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4620-4620" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -959,10 +960,10 @@
           </code>
           <div class="tip" id="3803">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4602-4602" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4602-4602" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -977,10 +978,10 @@
           </code>
           <div class="tip" id="3804">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4606-4606" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4606-4606" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -995,10 +996,10 @@
           </code>
           <div class="tip" id="3805">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4608-4608" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4608-4608" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1013,10 +1014,10 @@
           </code>
           <div class="tip" id="3806">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4607-4607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4607-4607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1031,10 +1032,10 @@
           </code>
           <div class="tip" id="3807">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4618-4618" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4618-4618" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1049,10 +1050,10 @@
           </code>
           <div class="tip" id="3808">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4466-4466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4466-4466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1070,10 +1071,10 @@
           </code>
           <div class="tip" id="3809">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4466-4466" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4466-4466" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1091,10 +1092,10 @@
           </code>
           <div class="tip" id="3810">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4548-4548" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4548-4548" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1112,10 +1113,10 @@
           </code>
           <div class="tip" id="3811">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4548-4548" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4548-4548" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1133,10 +1134,10 @@
           </code>
           <div class="tip" id="3812">
             <strong>Signature:</strong> unit -&gt; Stream<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4493-4493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4493-4493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1152,10 +1153,10 @@
           </code>
           <div class="tip" id="3813">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4493-4493" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4493-4493" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1171,10 +1172,10 @@
           </code>
           <div class="tip" id="3814">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4513-4513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4513-4513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1192,10 +1193,10 @@
           </code>
           <div class="tip" id="3815">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4513-4513" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4513-4513" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1213,10 +1214,10 @@
           </code>
           <div class="tip" id="3816">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4589-4589" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4589-4589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1234,10 +1235,10 @@
           </code>
           <div class="tip" id="3817">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4589-4589" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4589-4589" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1255,10 +1256,10 @@
           </code>
           <div class="tip" id="3818">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4456-4456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4456-4456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1274,10 +1275,10 @@
           </code>
           <div class="tip" id="3819">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4456-4456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4456-4456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1293,10 +1294,10 @@
           </code>
           <div class="tip" id="3820">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4484-4484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4484-4484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1314,10 +1315,10 @@
           </code>
           <div class="tip" id="3821">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4484-4484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4484-4484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1335,10 +1336,10 @@
           </code>
           <div class="tip" id="3822">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4461-4461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4461-4461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1356,10 +1357,10 @@
           </code>
           <div class="tip" id="3823">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4461-4461" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4461-4461" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="3824">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4503-4503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4503-4503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1398,10 +1399,10 @@
           </code>
           <div class="tip" id="3825">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4503-4503" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4503-4503" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1419,10 +1420,10 @@
           </code>
           <div class="tip" id="3826">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4579-4579" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4579-4579" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1440,10 +1441,10 @@
           </code>
           <div class="tip" id="3827">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4579-4579" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4579-4579" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1461,10 +1462,10 @@
           </code>
           <div class="tip" id="3828">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4508-4508" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4508-4508" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1482,10 +1483,10 @@
           </code>
           <div class="tip" id="3829">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4508-4508" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4508-4508" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1503,10 +1504,10 @@
           </code>
           <div class="tip" id="3830">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4584-4584" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4584-4584" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1524,10 +1525,10 @@
           </code>
           <div class="tip" id="3831">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4584-4584" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4584-4584" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1545,10 +1546,10 @@
           </code>
           <div class="tip" id="3832">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4498-4498" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4498-4498" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1566,10 +1567,10 @@
           </code>
           <div class="tip" id="3833">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4498-4498" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4498-4498" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1587,10 +1588,10 @@
           </code>
           <div class="tip" id="3834">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4518-4518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4518-4518" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1608,10 +1609,10 @@
           </code>
           <div class="tip" id="3835">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4518-4518" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4518-4518" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1629,10 +1630,10 @@
           </code>
           <div class="tip" id="3836">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4528-4528" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4528-4528" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1650,10 +1651,10 @@
           </code>
           <div class="tip" id="3837">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4528-4528" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4528-4528" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1671,10 +1672,10 @@
           </code>
           <div class="tip" id="3838">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4523-4523" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4523-4523" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1692,10 +1693,10 @@
           </code>
           <div class="tip" id="3839">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4523-4523" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4523-4523" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1713,10 +1714,10 @@
           </code>
           <div class="tip" id="3840">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4574-4574" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4574-4574" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1734,10 +1735,10 @@
           </code>
           <div class="tip" id="3841">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4574-4574" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4574-4574" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1759,7 +1760,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -1822,6 +1823,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-textfont.html
+++ b/docs/reference/xplot-plotly-graph-textfont.html
@@ -5,7 +5,7 @@
     <title>Textfont - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Textfont</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3842">
             <strong>Signature:</strong> unit -&gt; Textfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1002-1002" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1002-1002" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3843">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1021-1021" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1021-1021" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3844">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1021-1021" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1021-1021" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3845">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1044-1044" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1044-1044" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3846">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1044-1044" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1044-1044" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3847">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1013-1013" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1013-1013" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -202,10 +203,10 @@
           </code>
           <div class="tip" id="3848">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1013-1013" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1013-1013" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -221,10 +222,10 @@
           </code>
           <div class="tip" id="3849">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1034-1034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1034-1034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -242,10 +243,10 @@
           </code>
           <div class="tip" id="3850">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1034-1034" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1034-1034" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="3851">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1051-1051" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1051-1051" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -281,10 +282,10 @@
           </code>
           <div class="tip" id="3852">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1056-1056" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1056-1056" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -299,10 +300,10 @@
           </code>
           <div class="tip" id="3853">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1049-1049" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1049-1049" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -317,10 +318,10 @@
           </code>
           <div class="tip" id="3854">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1054-1054" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1054-1054" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="3855">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1050-1050" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1050-1050" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -353,10 +354,10 @@
           </code>
           <div class="tip" id="3856">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1055-1055" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1055-1055" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -371,10 +372,10 @@
           </code>
           <div class="tip" id="3857">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1017-1017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1017-1017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -390,10 +391,10 @@
           </code>
           <div class="tip" id="3858">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1017-1017" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1017-1017" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -409,10 +410,10 @@
           </code>
           <div class="tip" id="3859">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1039-1039" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1039-1039" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -430,10 +431,10 @@
           </code>
           <div class="tip" id="3860">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1039-1039" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1039-1039" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -455,7 +456,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -518,6 +519,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-tickfont.html
+++ b/docs/reference/xplot-plotly-graph-tickfont.html
@@ -5,7 +5,7 @@
     <title>Tickfont - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Tickfont</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3861">
             <strong>Signature:</strong> unit -&gt; Tickfont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1094-1094" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1094-1094" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3862">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1111-1111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1111-1111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3863">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1111-1111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1111-1111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3864">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1103-1103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1103-1103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3865">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1103-1103" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1103-1103" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3866">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1125-1125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1125-1125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="3867">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1123-1123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1123-1123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="3868">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1124-1124" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1124-1124" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="3869">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1107-1107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1107-1107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -256,10 +257,10 @@
           </code>
           <div class="tip" id="3870">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1107-1107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1107-1107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-titlefont.html
+++ b/docs/reference/xplot-plotly-graph-titlefont.html
@@ -5,7 +5,7 @@
     <title>Titlefont - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Titlefont</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3871">
             <strong>Signature:</strong> unit -&gt; Titlefont<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1058-1058" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1058-1058" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3872">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1075-1075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1075-1075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3873">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1075-1075" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1075-1075" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3874">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1067-1067" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1067-1067" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3875">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1067-1067" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1067-1067" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3876">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1090-1090" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1090-1090" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -201,10 +202,10 @@
           </code>
           <div class="tip" id="3877">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1088-1088" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1088-1088" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -219,10 +220,10 @@
           </code>
           <div class="tip" id="3878">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1089-1089" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1089-1089" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -237,10 +238,10 @@
           </code>
           <div class="tip" id="3879">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1071-1071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1071-1071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -256,10 +257,10 @@
           </code>
           <div class="tip" id="3880">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1071-1071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L1071-1071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -279,7 +280,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -342,6 +343,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-trace.html
+++ b/docs/reference/xplot-plotly-graph-trace.html
@@ -5,7 +5,7 @@
     <title>Trace - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Trace</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3881">
             <strong>Signature:</strong> unit -&gt; Trace<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4-4" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L4-4" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3882">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L9-9" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L9-9" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="3883">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L9-9" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L9-9" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="3884">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L13-13" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L13-13" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -167,7 +168,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -230,6 +231,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-up.html
+++ b/docs/reference/xplot-plotly-graph-up.html
@@ -5,7 +5,7 @@
     <title>Up - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Up</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3885">
             <strong>Signature:</strong> unit -&gt; Up<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6352-6352" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6352-6352" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3886">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6380-6380" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6380-6380" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -121,10 +122,10 @@
           </code>
           <div class="tip" id="3887">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6381-6381" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6381-6381" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -139,10 +140,10 @@
           </code>
           <div class="tip" id="3888">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6382-6382" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6382-6382" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -157,10 +158,10 @@
           </code>
           <div class="tip" id="3889">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6360-6360" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6360-6360" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -176,10 +177,10 @@
           </code>
           <div class="tip" id="3890">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6360-6360" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6360-6360" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -195,10 +196,10 @@
           </code>
           <div class="tip" id="3891">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6364-6364" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6364-6364" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -214,10 +215,10 @@
           </code>
           <div class="tip" id="3892">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6364-6364" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6364-6364" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -233,10 +234,10 @@
           </code>
           <div class="tip" id="3893">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6368-6368" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6368-6368" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="3894">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6368-6368" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6368-6368" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -275,7 +276,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -338,6 +339,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-x.html
+++ b/docs/reference/xplot-plotly-graph-x.html
@@ -5,7 +5,7 @@
     <title>X - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>X</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3895">
             <strong>Signature:</strong> unit -&gt; X<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L273-273" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L273-273" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3896">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L310-310" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L310-310" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3897">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L310-310" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L310-310" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3898">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L322-322" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L322-322" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="3899">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L322-322" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L322-322" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="3900">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L326-326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L326-326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="3901">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L326-326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L326-326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="3902">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L330-330" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L330-330" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="3903">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L330-330" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L330-330" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="3904">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L293-293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L293-293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -276,10 +277,10 @@
           </code>
           <div class="tip" id="3905">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L293-293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L293-293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="3906">
             <strong>Signature:</strong> unit -&gt; Project<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L306-306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L306-306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="3907">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L306-306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L306-306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="3908">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L298-298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L298-298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -356,10 +357,10 @@
           </code>
           <div class="tip" id="3909">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L298-298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L298-298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -377,10 +378,10 @@
           </code>
           <div class="tip" id="3910">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L339-339" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L339-339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -395,10 +396,10 @@
           </code>
           <div class="tip" id="3911">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L342-342" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L342-342" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -413,10 +414,10 @@
           </code>
           <div class="tip" id="3912">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L343-343" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L343-343" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3913">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L344-344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L344-344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -449,10 +450,10 @@
           </code>
           <div class="tip" id="3914">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L335-335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L335-335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -467,10 +468,10 @@
           </code>
           <div class="tip" id="3915">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L338-338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L338-338" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -485,10 +486,10 @@
           </code>
           <div class="tip" id="3916">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L336-336" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L336-336" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -503,10 +504,10 @@
           </code>
           <div class="tip" id="3917">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L334-334" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L334-334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -521,10 +522,10 @@
           </code>
           <div class="tip" id="3918">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L340-340" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L340-340" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -539,10 +540,10 @@
           </code>
           <div class="tip" id="3919">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L341-341" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L341-341" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="3920">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L288-288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L288-288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="3921">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L288-288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L288-288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="3922">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L314-314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L314-314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -618,10 +619,10 @@
           </code>
           <div class="tip" id="3923">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L314-314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L314-314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -637,10 +638,10 @@
           </code>
           <div class="tip" id="3924">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L318-318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L318-318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -656,10 +657,10 @@
           </code>
           <div class="tip" id="3925">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L318-318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L318-318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,7 +680,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -742,6 +743,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-xaxis.html
+++ b/docs/reference/xplot-plotly-graph-xaxis.html
@@ -5,7 +5,7 @@
     <title>Xaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Xaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="3926">
             <strong>Signature:</strong> unit -&gt; Xaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5581-5581" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5581-5581" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="3927">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5855-5855" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5855-5855" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="3928">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5855-5855" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5855-5855" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="3929">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5831-5831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5831-5831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="3930">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5831-5831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5831-5831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="3931">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5657-5657" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5657-5657" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="3932">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5657-5657" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5657-5657" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="3933">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5638-5638" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5638-5638" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="3934">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5638-5638" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5638-5638" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="3935">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5899-5899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5899-5899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -284,10 +285,10 @@
           </code>
           <div class="tip" id="3936">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5899-5899" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5899-5899" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="3937">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5846-5846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5846-5846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="3938">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5846-5846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5846-5846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="3939">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5692-5692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5692-5692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="3940">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5692-5692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5692-5692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="3941">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5771-5771" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5771-5771" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="3942">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5771-5771" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5771-5771" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="3943">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5672-5672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5672-5672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="3944">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5672-5672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5672-5672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="3945">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5806-5806" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5806-5806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="3946">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5806-5806" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5806-5806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="3947">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5811-5811" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5811-5811" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="3948">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5811-5811" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5811-5811" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="3949">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5781-5781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5781-5781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="3950">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5781-5781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5781-5781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="3951">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5791-5791" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5791-5791" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -620,10 +621,10 @@
           </code>
           <div class="tip" id="3952">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5791-5791" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5791-5791" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="3953">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5796-5796" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5796-5796" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="3954">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5796-5796" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5796-5796" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="3955">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5712-5712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5712-5712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -704,10 +705,10 @@
           </code>
           <div class="tip" id="3956">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5712-5712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5712-5712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="3957">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5682-5682" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5682-5682" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -746,10 +747,10 @@
           </code>
           <div class="tip" id="3958">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5682-5682" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5682-5682" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -767,10 +768,10 @@
           </code>
           <div class="tip" id="3959">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5841-5841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5841-5841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -788,10 +789,10 @@
           </code>
           <div class="tip" id="3960">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5841-5841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5841-5841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -809,10 +810,10 @@
           </code>
           <div class="tip" id="3961">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5851-5851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5851-5851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -830,10 +831,10 @@
           </code>
           <div class="tip" id="3962">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5851-5851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5851-5851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -851,10 +852,10 @@
           </code>
           <div class="tip" id="3963">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5667-5667" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5667-5667" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -872,10 +873,10 @@
           </code>
           <div class="tip" id="3964">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5667-5667" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5667-5667" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -893,10 +894,10 @@
           </code>
           <div class="tip" id="3965">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5662-5662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5662-5662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -914,10 +915,10 @@
           </code>
           <div class="tip" id="3966">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5662-5662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5662-5662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -935,10 +936,10 @@
           </code>
           <div class="tip" id="3967">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5952-5952" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5952-5952" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -953,10 +954,10 @@
           </code>
           <div class="tip" id="3968">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5947-5947" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5947-5947" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -971,10 +972,10 @@
           </code>
           <div class="tip" id="3969">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5912-5912" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5912-5912" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -989,10 +990,10 @@
           </code>
           <div class="tip" id="3970">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5908-5908" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5908-5908" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,10 +1008,10 @@
           </code>
           <div class="tip" id="3971">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5961-5961" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5961-5961" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1025,10 +1026,10 @@
           </code>
           <div class="tip" id="3972">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5950-5950" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5950-5950" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1043,10 +1044,10 @@
           </code>
           <div class="tip" id="3973">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5919-5919" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5919-5919" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1061,10 +1062,10 @@
           </code>
           <div class="tip" id="3974">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5935-5935" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5935-5935" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1079,10 +1080,10 @@
           </code>
           <div class="tip" id="3975">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5915-5915" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5915-5915" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1097,10 +1098,10 @@
           </code>
           <div class="tip" id="3976">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5942-5942" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5942-5942" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1115,10 +1116,10 @@
           </code>
           <div class="tip" id="3977">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5943-5943" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5943-5943" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1133,10 +1134,10 @@
           </code>
           <div class="tip" id="3978">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5937-5937" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5937-5937" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1151,10 +1152,10 @@
           </code>
           <div class="tip" id="3979">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5939-5939" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5939-5939" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1169,10 +1170,10 @@
           </code>
           <div class="tip" id="3980">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5940-5940" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5940-5940" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1187,10 +1188,10 @@
           </code>
           <div class="tip" id="3981">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5923-5923" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5923-5923" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1205,10 +1206,10 @@
           </code>
           <div class="tip" id="3982">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5917-5917" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5917-5917" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1223,10 +1224,10 @@
           </code>
           <div class="tip" id="3983">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5949-5949" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5949-5949" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1241,10 +1242,10 @@
           </code>
           <div class="tip" id="3984">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5951-5951" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5951-5951" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1259,10 +1260,10 @@
           </code>
           <div class="tip" id="3985">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5914-5914" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5914-5914" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1277,10 +1278,10 @@
           </code>
           <div class="tip" id="3986">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5913-5913" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5913-5913" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1295,10 +1296,10 @@
           </code>
           <div class="tip" id="3987">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5962-5962" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5962-5962" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1313,10 +1314,10 @@
           </code>
           <div class="tip" id="3988">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5960-5960" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5960-5960" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1331,10 +1332,10 @@
           </code>
           <div class="tip" id="3989">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5934-5934" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5934-5934" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1349,10 +1350,10 @@
           </code>
           <div class="tip" id="3990">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5941-5941" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5941-5941" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1367,10 +1368,10 @@
           </code>
           <div class="tip" id="3991">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5938-5938" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5938-5938" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1385,10 +1386,10 @@
           </code>
           <div class="tip" id="3992">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5956-5956" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5956-5956" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1403,10 +1404,10 @@
           </code>
           <div class="tip" id="3993">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5927-5927" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5927-5927" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1421,10 +1422,10 @@
           </code>
           <div class="tip" id="3994">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5931-5931" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5931-5931" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1439,10 +1440,10 @@
           </code>
           <div class="tip" id="3995">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5933-5933" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5933-5933" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1457,10 +1458,10 @@
           </code>
           <div class="tip" id="3996">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5948-5948" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5948-5948" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1475,10 +1476,10 @@
           </code>
           <div class="tip" id="3997">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5959-5959" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5959-5959" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1493,10 +1494,10 @@
           </code>
           <div class="tip" id="3998">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5957-5957" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5957-5957" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1511,10 +1512,10 @@
           </code>
           <div class="tip" id="3999">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5958-5958" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5958-5958" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1529,10 +1530,10 @@
           </code>
           <div class="tip" id="4000">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5918-5918" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5918-5918" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1547,10 +1548,10 @@
           </code>
           <div class="tip" id="4001">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5929-5929" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5929-5929" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1565,10 +1566,10 @@
           </code>
           <div class="tip" id="4002">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5926-5926" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5926-5926" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1583,10 +1584,10 @@
           </code>
           <div class="tip" id="4003">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5928-5928" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5928-5928" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1601,10 +1602,10 @@
           </code>
           <div class="tip" id="4004">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5936-5936" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5936-5936" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1619,10 +1620,10 @@
           </code>
           <div class="tip" id="4005">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5924-5924" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5924-5924" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1637,10 +1638,10 @@
           </code>
           <div class="tip" id="4006">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5916-5916" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5916-5916" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1655,10 +1656,10 @@
           </code>
           <div class="tip" id="4007">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5930-5930" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5930-5930" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1673,10 +1674,10 @@
           </code>
           <div class="tip" id="4008">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5922-5922" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5922-5922" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1691,10 +1692,10 @@
           </code>
           <div class="tip" id="4009">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5932-5932" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5932-5932" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1709,10 +1710,10 @@
           </code>
           <div class="tip" id="4010">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5921-5921" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5921-5921" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1727,10 +1728,10 @@
           </code>
           <div class="tip" id="4011">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5955-5955" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5955-5955" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1745,10 +1746,10 @@
           </code>
           <div class="tip" id="4012">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5920-5920" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5920-5920" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1763,10 +1764,10 @@
           </code>
           <div class="tip" id="4013">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5954-5954" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5954-5954" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1781,10 +1782,10 @@
           </code>
           <div class="tip" id="4014">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5925-5925" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5925-5925" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1799,10 +1800,10 @@
           </code>
           <div class="tip" id="4015">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5909-5909" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5909-5909" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1817,10 +1818,10 @@
           </code>
           <div class="tip" id="4016">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5910-5910" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5910-5910" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1835,10 +1836,10 @@
           </code>
           <div class="tip" id="4017">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5911-5911" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5911-5911" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1853,10 +1854,10 @@
           </code>
           <div class="tip" id="4018">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5944-5944" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5944-5944" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1871,10 +1872,10 @@
           </code>
           <div class="tip" id="4019">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5945-5945" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5945-5945" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1889,10 +1890,10 @@
           </code>
           <div class="tip" id="4020">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5946-5946" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5946-5946" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1907,10 +1908,10 @@
           </code>
           <div class="tip" id="4021">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5904-5904" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5904-5904" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1928,10 +1929,10 @@
           </code>
           <div class="tip" id="4022">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5904-5904" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5904-5904" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1949,10 +1950,10 @@
           </code>
           <div class="tip" id="4023">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5894-5894" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5894-5894" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1970,10 +1971,10 @@
           </code>
           <div class="tip" id="4024">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5894-5894" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5894-5894" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1991,10 +1992,10 @@
           </code>
           <div class="tip" id="4025">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5766-5766" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5766-5766" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2012,10 +2013,10 @@
           </code>
           <div class="tip" id="4026">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5766-5766" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5766-5766" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2033,10 +2034,10 @@
           </code>
           <div class="tip" id="4027">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5801-5801" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5801-5801" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2054,10 +2055,10 @@
           </code>
           <div class="tip" id="4028">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5801-5801" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5801-5801" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2075,10 +2076,10 @@
           </code>
           <div class="tip" id="4029">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5786-5786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5786-5786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2096,10 +2097,10 @@
           </code>
           <div class="tip" id="4030">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5786-5786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5786-5786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2117,10 +2118,10 @@
           </code>
           <div class="tip" id="4031">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5874-5874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5874-5874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2138,10 +2139,10 @@
           </code>
           <div class="tip" id="4032">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5874-5874" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5874-5874" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2159,10 +2160,10 @@
           </code>
           <div class="tip" id="4033">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5732-5732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5732-5732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2180,10 +2181,10 @@
           </code>
           <div class="tip" id="4034">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5732-5732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5732-5732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2201,10 +2202,10 @@
           </code>
           <div class="tip" id="4035">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5751-5751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5751-5751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2222,10 +2223,10 @@
           </code>
           <div class="tip" id="4036">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5751-5751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5751-5751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2243,10 +2244,10 @@
           </code>
           <div class="tip" id="4037">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5761-5761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5761-5761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2264,10 +2265,10 @@
           </code>
           <div class="tip" id="4038">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5761-5761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5761-5761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2285,10 +2286,10 @@
           </code>
           <div class="tip" id="4039">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5836-5836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5836-5836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2306,10 +2307,10 @@
           </code>
           <div class="tip" id="4040">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5836-5836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5836-5836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2327,10 +2328,10 @@
           </code>
           <div class="tip" id="4041">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5889-5889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5889-5889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2348,10 +2349,10 @@
           </code>
           <div class="tip" id="4042">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5889-5889" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5889-5889" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2369,10 +2370,10 @@
           </code>
           <div class="tip" id="4043">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5879-5879" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5879-5879" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2390,10 +2391,10 @@
           </code>
           <div class="tip" id="4044">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5879-5879" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5879-5879" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2411,10 +2412,10 @@
           </code>
           <div class="tip" id="4045">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5884-5884" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5884-5884" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2432,10 +2433,10 @@
           </code>
           <div class="tip" id="4046">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5884-5884" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5884-5884" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2453,10 +2454,10 @@
           </code>
           <div class="tip" id="4047">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5687-5687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5687-5687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2474,10 +2475,10 @@
           </code>
           <div class="tip" id="4048">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5687-5687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5687-5687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2495,10 +2496,10 @@
           </code>
           <div class="tip" id="4049">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5741-5741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5741-5741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2516,10 +2517,10 @@
           </code>
           <div class="tip" id="4050">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5741-5741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5741-5741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2537,10 +2538,10 @@
           </code>
           <div class="tip" id="4051">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5727-5727" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5727-5727" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2558,10 +2559,10 @@
           </code>
           <div class="tip" id="4052">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5727-5727" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5727-5727" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2579,10 +2580,10 @@
           </code>
           <div class="tip" id="4053">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5736-5736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5736-5736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2598,10 +2599,10 @@
           </code>
           <div class="tip" id="4054">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5736-5736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5736-5736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2617,10 +2618,10 @@
           </code>
           <div class="tip" id="4055">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5776-5776" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5776-5776" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2638,10 +2639,10 @@
           </code>
           <div class="tip" id="4056">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5776-5776" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5776-5776" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2659,10 +2660,10 @@
           </code>
           <div class="tip" id="4057">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5717-5717" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5717-5717" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2680,10 +2681,10 @@
           </code>
           <div class="tip" id="4058">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5717-5717" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5717-5717" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2701,10 +2702,10 @@
           </code>
           <div class="tip" id="4059">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5677-5677" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5677-5677" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2722,10 +2723,10 @@
           </code>
           <div class="tip" id="4060">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5677-5677" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5677-5677" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2743,10 +2744,10 @@
           </code>
           <div class="tip" id="4061">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5746-5746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5746-5746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2764,10 +2765,10 @@
           </code>
           <div class="tip" id="4062">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5746-5746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5746-5746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2785,10 +2786,10 @@
           </code>
           <div class="tip" id="4063">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5707-5707" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5707-5707" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2806,10 +2807,10 @@
           </code>
           <div class="tip" id="4064">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5707-5707" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5707-5707" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2827,10 +2828,10 @@
           </code>
           <div class="tip" id="4065">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5756-5756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5756-5756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2848,10 +2849,10 @@
           </code>
           <div class="tip" id="4066">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5756-5756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5756-5756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2869,10 +2870,10 @@
           </code>
           <div class="tip" id="4067">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5702-5702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5702-5702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2890,10 +2891,10 @@
           </code>
           <div class="tip" id="4068">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5702-5702" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5702-5702" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2911,10 +2912,10 @@
           </code>
           <div class="tip" id="4069">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5869-5869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5869-5869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2932,10 +2933,10 @@
           </code>
           <div class="tip" id="4070">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5869-5869" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5869-5869" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2953,10 +2954,10 @@
           </code>
           <div class="tip" id="4071">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5697-5697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5697-5697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2974,10 +2975,10 @@
           </code>
           <div class="tip" id="4072">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5697-5697" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5697-5697" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2995,10 +2996,10 @@
           </code>
           <div class="tip" id="4073">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5864-5864" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5864-5864" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3016,10 +3017,10 @@
           </code>
           <div class="tip" id="4074">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5864-5864" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5864-5864" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3037,10 +3038,10 @@
           </code>
           <div class="tip" id="4075">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5722-5722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5722-5722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3058,10 +3059,10 @@
           </code>
           <div class="tip" id="4076">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5722-5722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5722-5722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3079,10 +3080,10 @@
           </code>
           <div class="tip" id="4077">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5643-5643" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5643-5643" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3100,10 +3101,10 @@
           </code>
           <div class="tip" id="4078">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5643-5643" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5643-5643" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3121,10 +3122,10 @@
           </code>
           <div class="tip" id="4079">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5647-5647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5647-5647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3140,10 +3141,10 @@
           </code>
           <div class="tip" id="4080">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5647-5647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5647-5647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3159,10 +3160,10 @@
           </code>
           <div class="tip" id="4081">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5652-5652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5652-5652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3180,10 +3181,10 @@
           </code>
           <div class="tip" id="4082">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5652-5652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5652-5652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3201,10 +3202,10 @@
           </code>
           <div class="tip" id="4083">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5816-5816" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5816-5816" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3222,10 +3223,10 @@
           </code>
           <div class="tip" id="4084">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5816-5816" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5816-5816" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3243,10 +3244,10 @@
           </code>
           <div class="tip" id="4085">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5821-5821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5821-5821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3264,10 +3265,10 @@
           </code>
           <div class="tip" id="4086">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5821-5821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5821-5821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3285,10 +3286,10 @@
           </code>
           <div class="tip" id="4087">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5826-5826" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5826-5826" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3306,10 +3307,10 @@
           </code>
           <div class="tip" id="4088">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5826-5826" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5826-5826" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3331,7 +3332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -3394,6 +3395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-xbins.html
+++ b/docs/reference/xplot-plotly-graph-xbins.html
@@ -5,7 +5,7 @@
     <title>Xbins - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Xbins</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4089">
             <strong>Signature:</strong> unit -&gt; Xbins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L704-704" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L704-704" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4090">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L717-717" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L717-717" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="4091">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L717-717" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L717-717" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="4092">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L731-731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L731-731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,10 +164,10 @@
           </code>
           <div class="tip" id="4093">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L732-732" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L732-732" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -181,10 +182,10 @@
           </code>
           <div class="tip" id="4094">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L730-730" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L730-730" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -199,10 +200,10 @@
           </code>
           <div class="tip" id="4095">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L722-722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L722-722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -220,10 +221,10 @@
           </code>
           <div class="tip" id="4096">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L722-722" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L722-722" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -241,10 +242,10 @@
           </code>
           <div class="tip" id="4097">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L712-712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L712-712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -262,10 +263,10 @@
           </code>
           <div class="tip" id="4098">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L712-712" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L712-712" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -287,7 +288,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -350,6 +351,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-y.html
+++ b/docs/reference/xplot-plotly-graph-y.html
@@ -5,7 +5,7 @@
     <title>Y - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Y</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4099">
             <strong>Signature:</strong> unit -&gt; Y<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L346-346" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L346-346" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4100">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L383-383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L383-383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="4101">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L383-383" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L383-383" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="4102">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L395-395" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L395-395" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="4103">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L395-395" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L395-395" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="4104">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L399-399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L399-399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="4105">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L399-399" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L399-399" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="4106">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L403-403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L403-403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="4107">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L403-403" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L403-403" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="4108">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L366-366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L366-366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -276,10 +277,10 @@
           </code>
           <div class="tip" id="4109">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L366-366" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L366-366" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="4110">
             <strong>Signature:</strong> unit -&gt; Project<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L379-379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L379-379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="4111">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L379-379" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L379-379" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="4112">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L371-371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L371-371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -356,10 +357,10 @@
           </code>
           <div class="tip" id="4113">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L371-371" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L371-371" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -377,10 +378,10 @@
           </code>
           <div class="tip" id="4114">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L412-412" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L412-412" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -395,10 +396,10 @@
           </code>
           <div class="tip" id="4115">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L415-415" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L415-415" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -413,10 +414,10 @@
           </code>
           <div class="tip" id="4116">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L416-416" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L416-416" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="4117">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L417-417" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L417-417" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -449,10 +450,10 @@
           </code>
           <div class="tip" id="4118">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L408-408" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L408-408" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -467,10 +468,10 @@
           </code>
           <div class="tip" id="4119">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L411-411" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L411-411" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -485,10 +486,10 @@
           </code>
           <div class="tip" id="4120">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L409-409" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L409-409" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -503,10 +504,10 @@
           </code>
           <div class="tip" id="4121">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L407-407" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L407-407" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -521,10 +522,10 @@
           </code>
           <div class="tip" id="4122">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L413-413" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L413-413" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -539,10 +540,10 @@
           </code>
           <div class="tip" id="4123">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L414-414" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L414-414" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="4124">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L361-361" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L361-361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="4125">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L361-361" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L361-361" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="4126">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L387-387" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L387-387" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -618,10 +619,10 @@
           </code>
           <div class="tip" id="4127">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L387-387" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L387-387" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -637,10 +638,10 @@
           </code>
           <div class="tip" id="4128">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L391-391" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L391-391" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -656,10 +657,10 @@
           </code>
           <div class="tip" id="4129">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L391-391" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L391-391" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,7 +680,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -742,6 +743,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-yaxis.html
+++ b/docs/reference/xplot-plotly-graph-yaxis.html
@@ -5,7 +5,7 @@
     <title>Yaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Yaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4130">
             <strong>Signature:</strong> unit -&gt; Yaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5964-5964" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L5964-5964" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4131">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6239-6239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6239-6239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="4132">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6239-6239" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6239-6239" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="4133">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6215-6215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6215-6215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -162,10 +163,10 @@
           </code>
           <div class="tip" id="4134">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6215-6215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6215-6215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -183,10 +184,10 @@
           </code>
           <div class="tip" id="4135">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6041-6041" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6041-6041" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -204,10 +205,10 @@
           </code>
           <div class="tip" id="4136">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6041-6041" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6041-6041" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -225,10 +226,10 @@
           </code>
           <div class="tip" id="4137">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6022-6022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6022-6022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -244,10 +245,10 @@
           </code>
           <div class="tip" id="4138">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6022-6022" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6022-6022" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -263,10 +264,10 @@
           </code>
           <div class="tip" id="4139">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6283-6283" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6283-6283" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -284,10 +285,10 @@
           </code>
           <div class="tip" id="4140">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6283-6283" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6283-6283" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -305,10 +306,10 @@
           </code>
           <div class="tip" id="4141">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6230-6230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6230-6230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -326,10 +327,10 @@
           </code>
           <div class="tip" id="4142">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6230-6230" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6230-6230" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +348,10 @@
           </code>
           <div class="tip" id="4143">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6076-6076" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6076-6076" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +369,10 @@
           </code>
           <div class="tip" id="4144">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6076-6076" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6076-6076" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +390,10 @@
           </code>
           <div class="tip" id="4145">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6155-6155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6155-6155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -410,10 +411,10 @@
           </code>
           <div class="tip" id="4146">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6155-6155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6155-6155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="4147">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6056-6056" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6056-6056" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -452,10 +453,10 @@
           </code>
           <div class="tip" id="4148">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6056-6056" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6056-6056" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="4149">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6190-6190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6190-6190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -494,10 +495,10 @@
           </code>
           <div class="tip" id="4150">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6190-6190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6190-6190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -515,10 +516,10 @@
           </code>
           <div class="tip" id="4151">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6195-6195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6195-6195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -536,10 +537,10 @@
           </code>
           <div class="tip" id="4152">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6195-6195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6195-6195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="4153">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6165-6165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6165-6165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="4154">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6165-6165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6165-6165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="4155">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6175-6175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6175-6175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -620,10 +621,10 @@
           </code>
           <div class="tip" id="4156">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6175-6175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6175-6175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -641,10 +642,10 @@
           </code>
           <div class="tip" id="4157">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6180-6180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6180-6180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -662,10 +663,10 @@
           </code>
           <div class="tip" id="4158">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6180-6180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6180-6180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -683,10 +684,10 @@
           </code>
           <div class="tip" id="4159">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6096-6096" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6096-6096" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -704,10 +705,10 @@
           </code>
           <div class="tip" id="4160">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6096-6096" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6096-6096" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -725,10 +726,10 @@
           </code>
           <div class="tip" id="4161">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6066-6066" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6066-6066" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -746,10 +747,10 @@
           </code>
           <div class="tip" id="4162">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6066-6066" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6066-6066" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -767,10 +768,10 @@
           </code>
           <div class="tip" id="4163">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6225-6225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6225-6225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -788,10 +789,10 @@
           </code>
           <div class="tip" id="4164">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6225-6225" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6225-6225" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -809,10 +810,10 @@
           </code>
           <div class="tip" id="4165">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6235-6235" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6235-6235" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -830,10 +831,10 @@
           </code>
           <div class="tip" id="4166">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6235-6235" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6235-6235" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -851,10 +852,10 @@
           </code>
           <div class="tip" id="4167">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6051-6051" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6051-6051" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -872,10 +873,10 @@
           </code>
           <div class="tip" id="4168">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6051-6051" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6051-6051" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -893,10 +894,10 @@
           </code>
           <div class="tip" id="4169">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6046-6046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6046-6046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -914,10 +915,10 @@
           </code>
           <div class="tip" id="4170">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6046-6046" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6046-6046" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -935,10 +936,10 @@
           </code>
           <div class="tip" id="4171">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6336-6336" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6336-6336" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -953,10 +954,10 @@
           </code>
           <div class="tip" id="4172">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6331-6331" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6331-6331" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -971,10 +972,10 @@
           </code>
           <div class="tip" id="4173">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6296-6296" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6296-6296" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -989,10 +990,10 @@
           </code>
           <div class="tip" id="4174">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6292-6292" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6292-6292" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1007,10 +1008,10 @@
           </code>
           <div class="tip" id="4175">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6345-6345" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6345-6345" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1025,10 +1026,10 @@
           </code>
           <div class="tip" id="4176">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6334-6334" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6334-6334" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1043,10 +1044,10 @@
           </code>
           <div class="tip" id="4177">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6303-6303" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6303-6303" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1061,10 +1062,10 @@
           </code>
           <div class="tip" id="4178">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6319-6319" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6319-6319" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1079,10 +1080,10 @@
           </code>
           <div class="tip" id="4179">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6299-6299" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6299-6299" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1097,10 +1098,10 @@
           </code>
           <div class="tip" id="4180">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6326-6326" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6326-6326" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1115,10 +1116,10 @@
           </code>
           <div class="tip" id="4181">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6327-6327" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6327-6327" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1133,10 +1134,10 @@
           </code>
           <div class="tip" id="4182">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6321-6321" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6321-6321" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1151,10 +1152,10 @@
           </code>
           <div class="tip" id="4183">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6323-6323" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6323-6323" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1169,10 +1170,10 @@
           </code>
           <div class="tip" id="4184">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6324-6324" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6324-6324" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1187,10 +1188,10 @@
           </code>
           <div class="tip" id="4185">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6307-6307" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6307-6307" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1205,10 +1206,10 @@
           </code>
           <div class="tip" id="4186">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6301-6301" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6301-6301" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1223,10 +1224,10 @@
           </code>
           <div class="tip" id="4187">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6333-6333" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6333-6333" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1241,10 +1242,10 @@
           </code>
           <div class="tip" id="4188">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6335-6335" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6335-6335" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1259,10 +1260,10 @@
           </code>
           <div class="tip" id="4189">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6298-6298" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6298-6298" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1277,10 +1278,10 @@
           </code>
           <div class="tip" id="4190">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6297-6297" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6297-6297" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1295,10 +1296,10 @@
           </code>
           <div class="tip" id="4191">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6346-6346" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6346-6346" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1313,10 +1314,10 @@
           </code>
           <div class="tip" id="4192">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6344-6344" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6344-6344" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1331,10 +1332,10 @@
           </code>
           <div class="tip" id="4193">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6318-6318" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6318-6318" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1349,10 +1350,10 @@
           </code>
           <div class="tip" id="4194">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6325-6325" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6325-6325" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1367,10 +1368,10 @@
           </code>
           <div class="tip" id="4195">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6322-6322" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6322-6322" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1385,10 +1386,10 @@
           </code>
           <div class="tip" id="4196">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6340-6340" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6340-6340" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1403,10 +1404,10 @@
           </code>
           <div class="tip" id="4197">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6311-6311" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6311-6311" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1421,10 +1422,10 @@
           </code>
           <div class="tip" id="4198">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6315-6315" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6315-6315" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1439,10 +1440,10 @@
           </code>
           <div class="tip" id="4199">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6317-6317" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6317-6317" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1457,10 +1458,10 @@
           </code>
           <div class="tip" id="4200">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6332-6332" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6332-6332" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1475,10 +1476,10 @@
           </code>
           <div class="tip" id="4201">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6343-6343" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6343-6343" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1493,10 +1494,10 @@
           </code>
           <div class="tip" id="4202">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6341-6341" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6341-6341" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1511,10 +1512,10 @@
           </code>
           <div class="tip" id="4203">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6342-6342" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6342-6342" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1529,10 +1530,10 @@
           </code>
           <div class="tip" id="4204">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6302-6302" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6302-6302" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1547,10 +1548,10 @@
           </code>
           <div class="tip" id="4205">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6313-6313" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6313-6313" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1565,10 +1566,10 @@
           </code>
           <div class="tip" id="4206">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6310-6310" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6310-6310" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1583,10 +1584,10 @@
           </code>
           <div class="tip" id="4207">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6312-6312" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6312-6312" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1601,10 +1602,10 @@
           </code>
           <div class="tip" id="4208">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6320-6320" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6320-6320" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1619,10 +1620,10 @@
           </code>
           <div class="tip" id="4209">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6308-6308" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6308-6308" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1637,10 +1638,10 @@
           </code>
           <div class="tip" id="4210">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6300-6300" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6300-6300" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1655,10 +1656,10 @@
           </code>
           <div class="tip" id="4211">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6314-6314" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6314-6314" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1673,10 +1674,10 @@
           </code>
           <div class="tip" id="4212">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6306-6306" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6306-6306" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1691,10 +1692,10 @@
           </code>
           <div class="tip" id="4213">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6316-6316" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6316-6316" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1709,10 +1710,10 @@
           </code>
           <div class="tip" id="4214">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6305-6305" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6305-6305" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1727,10 +1728,10 @@
           </code>
           <div class="tip" id="4215">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6339-6339" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6339-6339" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1745,10 +1746,10 @@
           </code>
           <div class="tip" id="4216">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6304-6304" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6304-6304" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1763,10 +1764,10 @@
           </code>
           <div class="tip" id="4217">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6338-6338" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6338-6338" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1781,10 +1782,10 @@
           </code>
           <div class="tip" id="4218">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6309-6309" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6309-6309" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1799,10 +1800,10 @@
           </code>
           <div class="tip" id="4219">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6293-6293" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6293-6293" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1817,10 +1818,10 @@
           </code>
           <div class="tip" id="4220">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6294-6294" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6294-6294" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1835,10 +1836,10 @@
           </code>
           <div class="tip" id="4221">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6295-6295" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6295-6295" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1853,10 +1854,10 @@
           </code>
           <div class="tip" id="4222">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6328-6328" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6328-6328" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1871,10 +1872,10 @@
           </code>
           <div class="tip" id="4223">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6329-6329" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6329-6329" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1889,10 +1890,10 @@
           </code>
           <div class="tip" id="4224">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6330-6330" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6330-6330" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1907,10 +1908,10 @@
           </code>
           <div class="tip" id="4225">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6288-6288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6288-6288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1928,10 +1929,10 @@
           </code>
           <div class="tip" id="4226">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6288-6288" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6288-6288" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1949,10 +1950,10 @@
           </code>
           <div class="tip" id="4227">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6278-6278" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6278-6278" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1970,10 +1971,10 @@
           </code>
           <div class="tip" id="4228">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6278-6278" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6278-6278" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1991,10 +1992,10 @@
           </code>
           <div class="tip" id="4229">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6150-6150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6150-6150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2012,10 +2013,10 @@
           </code>
           <div class="tip" id="4230">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6150-6150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6150-6150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2033,10 +2034,10 @@
           </code>
           <div class="tip" id="4231">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6185-6185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6185-6185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2054,10 +2055,10 @@
           </code>
           <div class="tip" id="4232">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6185-6185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6185-6185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2075,10 +2076,10 @@
           </code>
           <div class="tip" id="4233">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6170-6170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6170-6170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2096,10 +2097,10 @@
           </code>
           <div class="tip" id="4234">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6170-6170" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6170-6170" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2117,10 +2118,10 @@
           </code>
           <div class="tip" id="4235">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6258-6258" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6258-6258" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2138,10 +2139,10 @@
           </code>
           <div class="tip" id="4236">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6258-6258" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6258-6258" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2159,10 +2160,10 @@
           </code>
           <div class="tip" id="4237">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6116-6116" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6116-6116" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2180,10 +2181,10 @@
           </code>
           <div class="tip" id="4238">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6116-6116" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6116-6116" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2201,10 +2202,10 @@
           </code>
           <div class="tip" id="4239">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6135-6135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6135-6135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2222,10 +2223,10 @@
           </code>
           <div class="tip" id="4240">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6135-6135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6135-6135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2243,10 +2244,10 @@
           </code>
           <div class="tip" id="4241">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6145-6145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6145-6145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2264,10 +2265,10 @@
           </code>
           <div class="tip" id="4242">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6145-6145" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6145-6145" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2285,10 +2286,10 @@
           </code>
           <div class="tip" id="4243">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6220-6220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6220-6220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2306,10 +2307,10 @@
           </code>
           <div class="tip" id="4244">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6220-6220" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6220-6220" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2327,10 +2328,10 @@
           </code>
           <div class="tip" id="4245">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6273-6273" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6273-6273" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2348,10 +2349,10 @@
           </code>
           <div class="tip" id="4246">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6273-6273" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6273-6273" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2369,10 +2370,10 @@
           </code>
           <div class="tip" id="4247">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6263-6263" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6263-6263" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2390,10 +2391,10 @@
           </code>
           <div class="tip" id="4248">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6263-6263" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6263-6263" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2411,10 +2412,10 @@
           </code>
           <div class="tip" id="4249">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6268-6268" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6268-6268" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2432,10 +2433,10 @@
           </code>
           <div class="tip" id="4250">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6268-6268" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6268-6268" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2453,10 +2454,10 @@
           </code>
           <div class="tip" id="4251">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6071-6071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6071-6071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2474,10 +2475,10 @@
           </code>
           <div class="tip" id="4252">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6071-6071" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6071-6071" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2495,10 +2496,10 @@
           </code>
           <div class="tip" id="4253">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6125-6125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6125-6125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2516,10 +2517,10 @@
           </code>
           <div class="tip" id="4254">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6125-6125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6125-6125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2537,10 +2538,10 @@
           </code>
           <div class="tip" id="4255">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6111-6111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6111-6111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2558,10 +2559,10 @@
           </code>
           <div class="tip" id="4256">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6111-6111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6111-6111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2579,10 +2580,10 @@
           </code>
           <div class="tip" id="4257">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6120-6120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6120-6120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2598,10 +2599,10 @@
           </code>
           <div class="tip" id="4258">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6120-6120" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6120-6120" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2617,10 +2618,10 @@
           </code>
           <div class="tip" id="4259">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6160-6160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6160-6160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2638,10 +2639,10 @@
           </code>
           <div class="tip" id="4260">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6160-6160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6160-6160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2659,10 +2660,10 @@
           </code>
           <div class="tip" id="4261">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6101-6101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6101-6101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2680,10 +2681,10 @@
           </code>
           <div class="tip" id="4262">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6101-6101" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6101-6101" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2701,10 +2702,10 @@
           </code>
           <div class="tip" id="4263">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6061-6061" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6061-6061" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2722,10 +2723,10 @@
           </code>
           <div class="tip" id="4264">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6061-6061" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6061-6061" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2743,10 +2744,10 @@
           </code>
           <div class="tip" id="4265">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6130-6130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6130-6130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2764,10 +2765,10 @@
           </code>
           <div class="tip" id="4266">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6130-6130" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6130-6130" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2785,10 +2786,10 @@
           </code>
           <div class="tip" id="4267">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6091-6091" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6091-6091" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2806,10 +2807,10 @@
           </code>
           <div class="tip" id="4268">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6091-6091" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6091-6091" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2827,10 +2828,10 @@
           </code>
           <div class="tip" id="4269">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6140-6140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6140-6140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2848,10 +2849,10 @@
           </code>
           <div class="tip" id="4270">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6140-6140" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6140-6140" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2869,10 +2870,10 @@
           </code>
           <div class="tip" id="4271">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6086-6086" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6086-6086" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2890,10 +2891,10 @@
           </code>
           <div class="tip" id="4272">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6086-6086" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6086-6086" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2911,10 +2912,10 @@
           </code>
           <div class="tip" id="4273">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6253-6253" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6253-6253" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2932,10 +2933,10 @@
           </code>
           <div class="tip" id="4274">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6253-6253" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6253-6253" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2953,10 +2954,10 @@
           </code>
           <div class="tip" id="4275">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6081-6081" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6081-6081" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2974,10 +2975,10 @@
           </code>
           <div class="tip" id="4276">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6081-6081" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6081-6081" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2995,10 +2996,10 @@
           </code>
           <div class="tip" id="4277">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6248-6248" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6248-6248" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3016,10 +3017,10 @@
           </code>
           <div class="tip" id="4278">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6248-6248" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6248-6248" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3037,10 +3038,10 @@
           </code>
           <div class="tip" id="4279">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6106-6106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6106-6106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3058,10 +3059,10 @@
           </code>
           <div class="tip" id="4280">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6106-6106" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6106-6106" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3079,10 +3080,10 @@
           </code>
           <div class="tip" id="4281">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6027-6027" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6027-6027" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3100,10 +3101,10 @@
           </code>
           <div class="tip" id="4282">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6027-6027" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6027-6027" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3121,10 +3122,10 @@
           </code>
           <div class="tip" id="4283">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6031-6031" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6031-6031" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3140,10 +3141,10 @@
           </code>
           <div class="tip" id="4284">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6031-6031" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6031-6031" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3159,10 +3160,10 @@
           </code>
           <div class="tip" id="4285">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6036-6036" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6036-6036" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3180,10 +3181,10 @@
           </code>
           <div class="tip" id="4286">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6036-6036" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6036-6036" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3201,10 +3202,10 @@
           </code>
           <div class="tip" id="4287">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6200-6200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6200-6200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3222,10 +3223,10 @@
           </code>
           <div class="tip" id="4288">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6200-6200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6200-6200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3243,10 +3244,10 @@
           </code>
           <div class="tip" id="4289">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6205-6205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6205-6205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3264,10 +3265,10 @@
           </code>
           <div class="tip" id="4290">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6205-6205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6205-6205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3285,10 +3286,10 @@
           </code>
           <div class="tip" id="4291">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6210-6210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6210-6210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3306,10 +3307,10 @@
           </code>
           <div class="tip" id="4292">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6210-6210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6210-6210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -3331,7 +3332,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -3394,6 +3395,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-ybins.html
+++ b/docs/reference/xplot-plotly-graph-ybins.html
@@ -5,7 +5,7 @@
     <title>Ybins - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Ybins</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4293">
             <strong>Signature:</strong> unit -&gt; Ybins<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L735-735" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L735-735" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4294">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L748-748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L748-748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="4295">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L748-748" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L748-748" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="4296">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L762-762" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L762-762" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -163,10 +164,10 @@
           </code>
           <div class="tip" id="4297">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L763-763" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L763-763" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -181,10 +182,10 @@
           </code>
           <div class="tip" id="4298">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L761-761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L761-761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -199,10 +200,10 @@
           </code>
           <div class="tip" id="4299">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L753-753" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L753-753" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -220,10 +221,10 @@
           </code>
           <div class="tip" id="4300">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L753-753" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L753-753" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -241,10 +242,10 @@
           </code>
           <div class="tip" id="4301">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L743-743" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L743-743" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -262,10 +263,10 @@
           </code>
           <div class="tip" id="4302">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L743-743" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L743-743" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -287,7 +288,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -350,6 +351,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-z.html
+++ b/docs/reference/xplot-plotly-graph-z.html
@@ -5,7 +5,7 @@
     <title>Z - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Z</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4303">
             <strong>Signature:</strong> unit -&gt; Z<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L419-419" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L419-419" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4304">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L456-456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L456-456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="4305">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L456-456" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L456-456" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="4306">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L468-468" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L468-468" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="4307">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L468-468" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L468-468" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="4308">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L472-472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L472-472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -198,10 +199,10 @@
           </code>
           <div class="tip" id="4309">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L472-472" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L472-472" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -217,10 +218,10 @@
           </code>
           <div class="tip" id="4310">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L476-476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L476-476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -236,10 +237,10 @@
           </code>
           <div class="tip" id="4311">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L476-476" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L476-476" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -255,10 +256,10 @@
           </code>
           <div class="tip" id="4312">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L439-439" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L439-439" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -276,10 +277,10 @@
           </code>
           <div class="tip" id="4313">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L439-439" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L439-439" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="4314">
             <strong>Signature:</strong> unit -&gt; Project<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L452-452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L452-452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="4315">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L452-452" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L452-452" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="4316">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L444-444" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L444-444" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -356,10 +357,10 @@
           </code>
           <div class="tip" id="4317">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L444-444" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L444-444" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -377,10 +378,10 @@
           </code>
           <div class="tip" id="4318">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L485-485" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L485-485" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -395,10 +396,10 @@
           </code>
           <div class="tip" id="4319">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L488-488" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L488-488" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -413,10 +414,10 @@
           </code>
           <div class="tip" id="4320">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L489-489" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L489-489" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -431,10 +432,10 @@
           </code>
           <div class="tip" id="4321">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L490-490" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L490-490" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -449,10 +450,10 @@
           </code>
           <div class="tip" id="4322">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L481-481" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L481-481" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -467,10 +468,10 @@
           </code>
           <div class="tip" id="4323">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L484-484" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L484-484" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -485,10 +486,10 @@
           </code>
           <div class="tip" id="4324">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L482-482" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L482-482" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -503,10 +504,10 @@
           </code>
           <div class="tip" id="4325">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L480-480" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L480-480" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -521,10 +522,10 @@
           </code>
           <div class="tip" id="4326">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L486-486" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L486-486" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -539,10 +540,10 @@
           </code>
           <div class="tip" id="4327">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L487-487" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L487-487" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -557,10 +558,10 @@
           </code>
           <div class="tip" id="4328">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L434-434" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L434-434" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -578,10 +579,10 @@
           </code>
           <div class="tip" id="4329">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L434-434" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L434-434" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -599,10 +600,10 @@
           </code>
           <div class="tip" id="4330">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L460-460" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L460-460" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -618,10 +619,10 @@
           </code>
           <div class="tip" id="4331">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L460-460" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L460-460" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -637,10 +638,10 @@
           </code>
           <div class="tip" id="4332">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L464-464" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L464-464" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -656,10 +657,10 @@
           </code>
           <div class="tip" id="4333">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L464-464" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L464-464" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -679,7 +680,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -742,6 +743,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph-zaxis.html
+++ b/docs/reference/xplot-plotly-graph-zaxis.html
@@ -5,7 +5,7 @@
     <title>Zaxis - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Zaxis</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-graph.html">Graph</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4334">
             <strong>Signature:</strong> unit -&gt; Zaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6516-6516" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6516-6516" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4335">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6617-6617" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6617-6617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -124,10 +125,10 @@
           </code>
           <div class="tip" id="4336">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6617-6617" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6617-6617" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -145,10 +146,10 @@
           </code>
           <div class="tip" id="4337">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6593-6593" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6593-6593" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -166,10 +167,10 @@
           </code>
           <div class="tip" id="4338">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6593-6593" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6593-6593" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +188,10 @@
           </code>
           <div class="tip" id="4339">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6652-6652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6652-6652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -208,10 +209,10 @@
           </code>
           <div class="tip" id="4340">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6652-6652" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6652-6652" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -229,10 +230,10 @@
           </code>
           <div class="tip" id="4341">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6731-6731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6731-6731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -250,10 +251,10 @@
           </code>
           <div class="tip" id="4342">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6731-6731" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6731-6731" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="4343">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6632-6632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6632-6632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -292,10 +293,10 @@
           </code>
           <div class="tip" id="4344">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6632-6632" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6632-6632" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -313,10 +314,10 @@
           </code>
           <div class="tip" id="4345">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6766-6766" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6766-6766" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -334,10 +335,10 @@
           </code>
           <div class="tip" id="4346">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6766-6766" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6766-6766" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -355,10 +356,10 @@
           </code>
           <div class="tip" id="4347">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6771-6771" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6771-6771" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -376,10 +377,10 @@
           </code>
           <div class="tip" id="4348">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6771-6771" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6771-6771" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -397,10 +398,10 @@
           </code>
           <div class="tip" id="4349">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6741-6741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6741-6741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -418,10 +419,10 @@
           </code>
           <div class="tip" id="4350">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6741-6741" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6741-6741" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -439,10 +440,10 @@
           </code>
           <div class="tip" id="4351">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6751-6751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6751-6751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -460,10 +461,10 @@
           </code>
           <div class="tip" id="4352">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6751-6751" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6751-6751" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -481,10 +482,10 @@
           </code>
           <div class="tip" id="4353">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6756-6756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6756-6756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -502,10 +503,10 @@
           </code>
           <div class="tip" id="4354">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6756-6756" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6756-6756" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -523,10 +524,10 @@
           </code>
           <div class="tip" id="4355">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6672-6672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6672-6672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -544,10 +545,10 @@
           </code>
           <div class="tip" id="4356">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6672-6672" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6672-6672" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -565,10 +566,10 @@
           </code>
           <div class="tip" id="4357">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6642-6642" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6642-6642" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -586,10 +587,10 @@
           </code>
           <div class="tip" id="4358">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6642-6642" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6642-6642" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -607,10 +608,10 @@
           </code>
           <div class="tip" id="4359">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6627-6627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6627-6627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -628,10 +629,10 @@
           </code>
           <div class="tip" id="4360">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6627-6627" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6627-6627" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -649,10 +650,10 @@
           </code>
           <div class="tip" id="4361">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6622-6622" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6622-6622" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -670,10 +671,10 @@
           </code>
           <div class="tip" id="4362">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6622-6622" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6622-6622" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -691,10 +692,10 @@
           </code>
           <div class="tip" id="4363">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6814-6814" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6814-6814" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -709,10 +710,10 @@
           </code>
           <div class="tip" id="4364">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6809-6809" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6809-6809" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -727,10 +728,10 @@
           </code>
           <div class="tip" id="4365">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6821-6821" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6821-6821" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -745,10 +746,10 @@
           </code>
           <div class="tip" id="4366">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6837-6837" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6837-6837" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -763,10 +764,10 @@
           </code>
           <div class="tip" id="4367">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6817-6817" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6817-6817" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -781,10 +782,10 @@
           </code>
           <div class="tip" id="4368">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6844-6844" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6844-6844" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -799,10 +800,10 @@
           </code>
           <div class="tip" id="4369">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6845-6845" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6845-6845" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -817,10 +818,10 @@
           </code>
           <div class="tip" id="4370">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6839-6839" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6839-6839" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -835,10 +836,10 @@
           </code>
           <div class="tip" id="4371">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6841-6841" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6841-6841" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -853,10 +854,10 @@
           </code>
           <div class="tip" id="4372">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6842-6842" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6842-6842" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -871,10 +872,10 @@
           </code>
           <div class="tip" id="4373">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6825-6825" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6825-6825" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -889,10 +890,10 @@
           </code>
           <div class="tip" id="4374">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6819-6819" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6819-6819" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -907,10 +908,10 @@
           </code>
           <div class="tip" id="4375">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6816-6816" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6816-6816" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -925,10 +926,10 @@
           </code>
           <div class="tip" id="4376">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6815-6815" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6815-6815" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -943,10 +944,10 @@
           </code>
           <div class="tip" id="4377">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6810-6810" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6810-6810" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -961,10 +962,10 @@
           </code>
           <div class="tip" id="4378">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6808-6808" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6808-6808" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -979,10 +980,10 @@
           </code>
           <div class="tip" id="4379">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6836-6836" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6836-6836" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -997,10 +998,10 @@
           </code>
           <div class="tip" id="4380">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6843-6843" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6843-6843" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1015,10 +1016,10 @@
           </code>
           <div class="tip" id="4381">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6840-6840" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6840-6840" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1033,10 +1034,10 @@
           </code>
           <div class="tip" id="4382">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6804-6804" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6804-6804" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1051,10 +1052,10 @@
           </code>
           <div class="tip" id="4383">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6829-6829" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6829-6829" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1069,10 +1070,10 @@
           </code>
           <div class="tip" id="4384">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6833-6833" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6833-6833" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1087,10 +1088,10 @@
           </code>
           <div class="tip" id="4385">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6835-6835" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6835-6835" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1105,10 +1106,10 @@
           </code>
           <div class="tip" id="4386">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6807-6807" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6807-6807" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1123,10 +1124,10 @@
           </code>
           <div class="tip" id="4387">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6805-6805" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6805-6805" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1141,10 +1142,10 @@
           </code>
           <div class="tip" id="4388">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6806-6806" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6806-6806" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1159,10 +1160,10 @@
           </code>
           <div class="tip" id="4389">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6820-6820" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6820-6820" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1177,10 +1178,10 @@
           </code>
           <div class="tip" id="4390">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6831-6831" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6831-6831" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1195,10 +1196,10 @@
           </code>
           <div class="tip" id="4391">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6828-6828" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6828-6828" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1213,10 +1214,10 @@
           </code>
           <div class="tip" id="4392">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6830-6830" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6830-6830" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1231,10 +1232,10 @@
           </code>
           <div class="tip" id="4393">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6838-6838" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6838-6838" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1249,10 +1250,10 @@
           </code>
           <div class="tip" id="4394">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6826-6826" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6826-6826" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1267,10 +1268,10 @@
           </code>
           <div class="tip" id="4395">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6818-6818" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6818-6818" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1285,10 +1286,10 @@
           </code>
           <div class="tip" id="4396">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6832-6832" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6832-6832" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1303,10 +1304,10 @@
           </code>
           <div class="tip" id="4397">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6824-6824" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6824-6824" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1321,10 +1322,10 @@
           </code>
           <div class="tip" id="4398">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6834-6834" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6834-6834" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1339,10 +1340,10 @@
           </code>
           <div class="tip" id="4399">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6823-6823" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6823-6823" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1357,10 +1358,10 @@
           </code>
           <div class="tip" id="4400">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6851-6851" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6851-6851" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1375,10 +1376,10 @@
           </code>
           <div class="tip" id="4401">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6822-6822" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6822-6822" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1393,10 +1394,10 @@
           </code>
           <div class="tip" id="4402">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6850-6850" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6850-6850" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1411,10 +1412,10 @@
           </code>
           <div class="tip" id="4403">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6827-6827" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6827-6827" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1429,10 +1430,10 @@
           </code>
           <div class="tip" id="4404">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6811-6811" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6811-6811" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1447,10 +1448,10 @@
           </code>
           <div class="tip" id="4405">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6812-6812" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6812-6812" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1465,10 +1466,10 @@
           </code>
           <div class="tip" id="4406">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6813-6813" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6813-6813" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1483,10 +1484,10 @@
           </code>
           <div class="tip" id="4407">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6846-6846" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6846-6846" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1501,10 +1502,10 @@
           </code>
           <div class="tip" id="4408">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6847-6847" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6847-6847" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1519,10 +1520,10 @@
           </code>
           <div class="tip" id="4409">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6848-6848" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6848-6848" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1537,10 +1538,10 @@
           </code>
           <div class="tip" id="4410">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6598-6598" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6598-6598" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1558,10 +1559,10 @@
           </code>
           <div class="tip" id="4411">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6598-6598" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6598-6598" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1579,10 +1580,10 @@
           </code>
           <div class="tip" id="4412">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6588-6588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6588-6588" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1600,10 +1601,10 @@
           </code>
           <div class="tip" id="4413">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6588-6588" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6588-6588" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1621,10 +1622,10 @@
           </code>
           <div class="tip" id="4414">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6726-6726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6726-6726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1642,10 +1643,10 @@
           </code>
           <div class="tip" id="4415">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6726-6726" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6726-6726" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1663,10 +1664,10 @@
           </code>
           <div class="tip" id="4416">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6761-6761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6761-6761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1684,10 +1685,10 @@
           </code>
           <div class="tip" id="4417">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6761-6761" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6761-6761" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1705,10 +1706,10 @@
           </code>
           <div class="tip" id="4418">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6746-6746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6746-6746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1726,10 +1727,10 @@
           </code>
           <div class="tip" id="4419">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6746-6746" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6746-6746" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1747,10 +1748,10 @@
           </code>
           <div class="tip" id="4420">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6568-6568" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6568-6568" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1768,10 +1769,10 @@
           </code>
           <div class="tip" id="4421">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6568-6568" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6568-6568" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1789,10 +1790,10 @@
           </code>
           <div class="tip" id="4422">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6692-6692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6692-6692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1810,10 +1811,10 @@
           </code>
           <div class="tip" id="4423">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6692-6692" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6692-6692" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1831,10 +1832,10 @@
           </code>
           <div class="tip" id="4424">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6711-6711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6711-6711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1852,10 +1853,10 @@
           </code>
           <div class="tip" id="4425">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6711-6711" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6711-6711" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1873,10 +1874,10 @@
           </code>
           <div class="tip" id="4426">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6721-6721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6721-6721" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1894,10 +1895,10 @@
           </code>
           <div class="tip" id="4427">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6721-6721" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6721-6721" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1915,10 +1916,10 @@
           </code>
           <div class="tip" id="4428">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6583-6583" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6583-6583" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1936,10 +1937,10 @@
           </code>
           <div class="tip" id="4429">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6583-6583" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6583-6583" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1957,10 +1958,10 @@
           </code>
           <div class="tip" id="4430">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6573-6573" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6573-6573" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1978,10 +1979,10 @@
           </code>
           <div class="tip" id="4431">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6573-6573" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6573-6573" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1999,10 +2000,10 @@
           </code>
           <div class="tip" id="4432">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6578-6578" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6578-6578" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2020,10 +2021,10 @@
           </code>
           <div class="tip" id="4433">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6578-6578" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6578-6578" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2041,10 +2042,10 @@
           </code>
           <div class="tip" id="4434">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6647-6647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6647-6647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2062,10 +2063,10 @@
           </code>
           <div class="tip" id="4435">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6647-6647" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6647-6647" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2083,10 +2084,10 @@
           </code>
           <div class="tip" id="4436">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6701-6701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6701-6701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2104,10 +2105,10 @@
           </code>
           <div class="tip" id="4437">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6701-6701" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6701-6701" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2125,10 +2126,10 @@
           </code>
           <div class="tip" id="4438">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6687-6687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6687-6687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2146,10 +2147,10 @@
           </code>
           <div class="tip" id="4439">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6687-6687" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6687-6687" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2167,10 +2168,10 @@
           </code>
           <div class="tip" id="4440">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6696-6696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6696-6696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2186,10 +2187,10 @@
           </code>
           <div class="tip" id="4441">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6696-6696" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6696-6696" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2205,10 +2206,10 @@
           </code>
           <div class="tip" id="4442">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6736-6736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6736-6736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2226,10 +2227,10 @@
           </code>
           <div class="tip" id="4443">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6736-6736" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6736-6736" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2247,10 +2248,10 @@
           </code>
           <div class="tip" id="4444">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6677-6677" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6677-6677" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2268,10 +2269,10 @@
           </code>
           <div class="tip" id="4445">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6677-6677" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6677-6677" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2289,10 +2290,10 @@
           </code>
           <div class="tip" id="4446">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6637-6637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6637-6637" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2310,10 +2311,10 @@
           </code>
           <div class="tip" id="4447">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6637-6637" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6637-6637" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2331,10 +2332,10 @@
           </code>
           <div class="tip" id="4448">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6706-6706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6706-6706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2352,10 +2353,10 @@
           </code>
           <div class="tip" id="4449">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6706-6706" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6706-6706" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2373,10 +2374,10 @@
           </code>
           <div class="tip" id="4450">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6667-6667" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6667-6667" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2394,10 +2395,10 @@
           </code>
           <div class="tip" id="4451">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6667-6667" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6667-6667" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2415,10 +2416,10 @@
           </code>
           <div class="tip" id="4452">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6716-6716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6716-6716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2436,10 +2437,10 @@
           </code>
           <div class="tip" id="4453">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6716-6716" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6716-6716" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2457,10 +2458,10 @@
           </code>
           <div class="tip" id="4454">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6662-6662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6662-6662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2478,10 +2479,10 @@
           </code>
           <div class="tip" id="4455">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6662-6662" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6662-6662" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2499,10 +2500,10 @@
           </code>
           <div class="tip" id="4456">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6800-6800" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6800-6800" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2520,10 +2521,10 @@
           </code>
           <div class="tip" id="4457">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6800-6800" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6800-6800" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2541,10 +2542,10 @@
           </code>
           <div class="tip" id="4458">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6657-6657" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6657-6657" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2562,10 +2563,10 @@
           </code>
           <div class="tip" id="4459">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6657-6657" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6657-6657" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2583,10 +2584,10 @@
           </code>
           <div class="tip" id="4460">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6795-6795" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6795-6795" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2604,10 +2605,10 @@
           </code>
           <div class="tip" id="4461">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6795-6795" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6795-6795" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2625,10 +2626,10 @@
           </code>
           <div class="tip" id="4462">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6682-6682" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6682-6682" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2646,10 +2647,10 @@
           </code>
           <div class="tip" id="4463">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6682-6682" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6682-6682" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2667,10 +2668,10 @@
           </code>
           <div class="tip" id="4464">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6603-6603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6603-6603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2688,10 +2689,10 @@
           </code>
           <div class="tip" id="4465">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6603-6603" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6603-6603" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2709,10 +2710,10 @@
           </code>
           <div class="tip" id="4466">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6607-6607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6607-6607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2728,10 +2729,10 @@
           </code>
           <div class="tip" id="4467">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6607-6607" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6607-6607" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2747,10 +2748,10 @@
           </code>
           <div class="tip" id="4468">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6612-6612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6612-6612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2768,10 +2769,10 @@
           </code>
           <div class="tip" id="4469">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6612-6612" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6612-6612" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2789,10 +2790,10 @@
           </code>
           <div class="tip" id="4470">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6776-6776" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6776-6776" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2810,10 +2811,10 @@
           </code>
           <div class="tip" id="4471">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6776-6776" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6776-6776" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2831,10 +2832,10 @@
           </code>
           <div class="tip" id="4472">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6781-6781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6781-6781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2852,10 +2853,10 @@
           </code>
           <div class="tip" id="4473">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6781-6781" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6781-6781" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2873,10 +2874,10 @@
           </code>
           <div class="tip" id="4474">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6786-6786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6786-6786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2894,10 +2895,10 @@
           </code>
           <div class="tip" id="4475">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6786-6786" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Graph.fs#L6786-6786" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2919,7 +2920,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2982,6 +2983,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-graph.html
+++ b/docs/reference/xplot-plotly-graph.html
@@ -5,7 +5,7 @@
     <title>Graph - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Graph</h1>
 <p>
   <span>Namespace: XPlot.Plotly</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -74,379 +79,505 @@
           <td class="type-name">
             <a href="xplot-plotly-graph-angularaxis.html">Angularaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-annotation.html">Annotation</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-annotations.html">Annotations</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-area.html">Area</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-aspectratio.html">Aspectratio</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-bar.html">Bar</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-box.html">Box</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-camera.html">Camera</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-candlestick.html">Candlestick</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-center.html">Center</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-choropleth.html">Choropleth</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-colorbar.html">Colorbar</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-contour.html">Contour</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-contours.html">Contours</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-domain.html">Domain</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-error_x.html">Error_x</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-error_y.html">Error_y</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-error_z.html">Error_z</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-eye.html">Eye</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-font.html">Font</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-geo.html">Geo</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-heatmap.html">Heatmap</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-histogram.html">Histogram</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-histogram2d.html">Histogram2d</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-histogram2dcontour.html">Histogram2dcontour</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-insidetextfont.html">Insidetextfont</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-items.html">Items</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-lataxis.html">Lataxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-legend.html">Legend</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-lighting.html">Lighting</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-line.html">Line</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-lonaxis.html">Lonaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-margin.html">Margin</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-marker.html">Marker</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-mesh3d.html">Mesh3d</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-outsidetextfont.html">Outsidetextfont</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-pie.html">Pie</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-project.html">Project</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-projection.html">Projection</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-radialaxis.html">Radialaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-rotation.html">Rotation</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-scatter.html">Scatter</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-scatter3d.html">Scatter3d</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-scattergeo.html">Scattergeo</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-scattergl.html">Scattergl</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-scene.html">Scene</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-shape.html">Shape</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-shapes.html">Shapes</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-stream.html">Stream</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-surface.html">Surface</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-textfont.html">Textfont</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-tickfont.html">Tickfont</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-titlefont.html">Titlefont</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-trace.html">Trace</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-up.html">Up</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-x.html">X</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-xaxis.html">Xaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-xbins.html">Xbins</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-y.html">Y</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-yaxis.html">Yaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-ybins.html">Ybins</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-z.html">Z</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
         <tr>
           <td class="type-name">
             <a href="xplot-plotly-graph-zaxis.html">Zaxis</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -463,7 +594,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -526,6 +657,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-html.html
+++ b/docs/reference/xplot-plotly-html.html
@@ -5,7 +5,7 @@
     <title>Html - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,7 +58,7 @@
 <h1>Html</h1>
 <p>
   <span>Namespace: XPlot.Plotly</span><br />
-</p>
+  </p>
 <div class="xmldoc">
 </div>
 
@@ -78,10 +78,10 @@
           </code>
           <div class="tip" id="54">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L22-22" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L22-22" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -96,10 +96,10 @@
           </code>
           <div class="tip" id="55">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L30-30" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L30-30" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,10 +114,10 @@
           </code>
           <div class="tip" id="56">
             <strong>Signature:</strong> string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L10-10" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L10-10" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -132,10 +132,10 @@
           </code>
           <div class="tip" id="57">
             <strong>Signature:</strong> html:string -&gt; pageId:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L38-38" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L38-38" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -156,7 +156,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -219,6 +219,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-key.html
+++ b/docs/reference/xplot-plotly-key.html
@@ -5,7 +5,7 @@
     <title>key - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>key</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+    </p>
 <div class="xmldoc">
 </div>
 
@@ -71,7 +72,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -134,6 +135,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-layout-layout.html
+++ b/docs/reference/xplot-plotly-layout-layout.html
@@ -5,7 +5,7 @@
     <title>Layout - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,9 +57,10 @@
 
 <h1>Layout</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-  <span>Parent Module: <a href="xplot-plotly-layout.html">Layout</a></span>
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+        <span>Parent Module: <a href="xplot-plotly-layout.html">Layout</a></span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Constructors</h3>
@@ -76,10 +77,10 @@
           </code>
           <div class="tip" id="4476">
             <strong>Signature:</strong> unit -&gt; Layout<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L4-4" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L4-4" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -103,10 +104,10 @@
           </code>
           <div class="tip" id="4477">
             <strong>Signature:</strong> unit -&gt; Angularaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -122,10 +123,10 @@
           </code>
           <div class="tip" id="4478">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -141,10 +142,10 @@
           </code>
           <div class="tip" id="4479">
             <strong>Signature:</strong> unit -&gt; seq&lt;Annotation&gt;<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -160,10 +161,10 @@
           </code>
           <div class="tip" id="4480">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -179,10 +180,10 @@
           </code>
           <div class="tip" id="4481">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -200,10 +201,10 @@
           </code>
           <div class="tip" id="4482">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -221,10 +222,10 @@
           </code>
           <div class="tip" id="4483">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -240,10 +241,10 @@
           </code>
           <div class="tip" id="4484">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -259,10 +260,10 @@
           </code>
           <div class="tip" id="4485">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -278,10 +279,10 @@
           </code>
           <div class="tip" id="4486">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -297,10 +298,10 @@
           </code>
           <div class="tip" id="4487">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -316,10 +317,10 @@
           </code>
           <div class="tip" id="4488">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -335,10 +336,10 @@
           </code>
           <div class="tip" id="4489">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -354,10 +355,10 @@
           </code>
           <div class="tip" id="4490">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -373,10 +374,10 @@
           </code>
           <div class="tip" id="4491">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -394,10 +395,10 @@
           </code>
           <div class="tip" id="4492">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -415,10 +416,10 @@
           </code>
           <div class="tip" id="4493">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -436,10 +437,10 @@
           </code>
           <div class="tip" id="4494">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -457,10 +458,10 @@
           </code>
           <div class="tip" id="4495">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -476,10 +477,10 @@
           </code>
           <div class="tip" id="4496">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -495,10 +496,10 @@
           </code>
           <div class="tip" id="4497">
             <strong>Signature:</strong> unit -&gt; Geo<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -514,10 +515,10 @@
           </code>
           <div class="tip" id="4498">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -533,10 +534,10 @@
           </code>
           <div class="tip" id="4499">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -554,10 +555,10 @@
           </code>
           <div class="tip" id="4500">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -575,10 +576,10 @@
           </code>
           <div class="tip" id="4501">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -596,10 +597,10 @@
           </code>
           <div class="tip" id="4502">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -617,10 +618,10 @@
           </code>
           <div class="tip" id="4503">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -638,10 +639,10 @@
           </code>
           <div class="tip" id="4504">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -659,10 +660,10 @@
           </code>
           <div class="tip" id="4505">
             <strong>Signature:</strong> unit -&gt; Legend<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -678,10 +679,10 @@
           </code>
           <div class="tip" id="4506">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -697,10 +698,10 @@
           </code>
           <div class="tip" id="4507">
             <strong>Signature:</strong> unit -&gt; Margin<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -716,10 +717,10 @@
           </code>
           <div class="tip" id="4508">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -735,10 +736,10 @@
           </code>
           <div class="tip" id="4509">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -756,10 +757,10 @@
           </code>
           <div class="tip" id="4510">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -777,10 +778,10 @@
           </code>
           <div class="tip" id="4511">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -798,10 +799,10 @@
           </code>
           <div class="tip" id="4512">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -819,10 +820,10 @@
           </code>
           <div class="tip" id="4513">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -840,10 +841,10 @@
           </code>
           <div class="tip" id="4514">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -861,10 +862,10 @@
           </code>
           <div class="tip" id="4515">
             <strong>Signature:</strong> unit -&gt; Radialaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -880,10 +881,10 @@
           </code>
           <div class="tip" id="4516">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -899,10 +900,10 @@
           </code>
           <div class="tip" id="4517">
             <strong>Signature:</strong> unit -&gt; Scene<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -918,10 +919,10 @@
           </code>
           <div class="tip" id="4518">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -937,10 +938,10 @@
           </code>
           <div class="tip" id="4519">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -958,10 +959,10 @@
           </code>
           <div class="tip" id="4520">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -979,10 +980,10 @@
           </code>
           <div class="tip" id="4521">
             <strong>Signature:</strong> unit -&gt; seq&lt;Shape&gt;<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -998,10 +999,10 @@
           </code>
           <div class="tip" id="4522">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1017,10 +1018,10 @@
           </code>
           <div class="tip" id="4523">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L212-212" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L212-212" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1035,10 +1036,10 @@
           </code>
           <div class="tip" id="4524">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L209-209" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L209-209" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1053,10 +1054,10 @@
           </code>
           <div class="tip" id="4525">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L188-188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L188-188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1071,10 +1072,10 @@
           </code>
           <div class="tip" id="4526">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L216-216" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L216-216" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1089,10 +1090,10 @@
           </code>
           <div class="tip" id="4527">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L217-217" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L217-217" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1107,10 +1108,10 @@
           </code>
           <div class="tip" id="4528">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L215-215" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L215-215" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1125,10 +1126,10 @@
           </code>
           <div class="tip" id="4529">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L218-218" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L218-218" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1143,10 +1144,10 @@
           </code>
           <div class="tip" id="4530">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L213-213" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L213-213" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1161,10 +1162,10 @@
           </code>
           <div class="tip" id="4531">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L198-198" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L198-198" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1179,10 +1180,10 @@
           </code>
           <div class="tip" id="4532">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L185-185" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L185-185" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1197,10 +1198,10 @@
           </code>
           <div class="tip" id="4533">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L207-207" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L207-207" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1215,10 +1216,10 @@
           </code>
           <div class="tip" id="4534">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L190-190" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L190-190" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1233,10 +1234,10 @@
           </code>
           <div class="tip" id="4535">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L195-195" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L195-195" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1251,10 +1252,10 @@
           </code>
           <div class="tip" id="4536">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L199-199" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L199-199" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1269,10 +1270,10 @@
           </code>
           <div class="tip" id="4537">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L208-208" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L208-208" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1287,10 +1288,10 @@
           </code>
           <div class="tip" id="4538">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L191-191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1305,10 +1306,10 @@
           </code>
           <div class="tip" id="4539">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L214-214" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L214-214" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1323,10 +1324,10 @@
           </code>
           <div class="tip" id="4540">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L192-192" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L192-192" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1341,10 +1342,10 @@
           </code>
           <div class="tip" id="4541">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L193-193" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L193-193" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1359,10 +1360,10 @@
           </code>
           <div class="tip" id="4542">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L211-211" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L211-211" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1377,10 +1378,10 @@
           </code>
           <div class="tip" id="4543">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L206-206" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L206-206" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1395,10 +1396,10 @@
           </code>
           <div class="tip" id="4544">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L194-194" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L194-194" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1413,10 +1414,10 @@
           </code>
           <div class="tip" id="4545">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L210-210" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L210-210" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1431,10 +1432,10 @@
           </code>
           <div class="tip" id="4546">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L197-197" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L197-197" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1449,10 +1450,10 @@
           </code>
           <div class="tip" id="4547">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L196-196" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L196-196" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1467,10 +1468,10 @@
           </code>
           <div class="tip" id="4548">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L186-186" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L186-186" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1485,10 +1486,10 @@
           </code>
           <div class="tip" id="4549">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L187-187" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L187-187" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1503,10 +1504,10 @@
           </code>
           <div class="tip" id="4550">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L189-189" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L189-189" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1521,10 +1522,10 @@
           </code>
           <div class="tip" id="4551">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L200-200" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L200-200" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1539,10 +1540,10 @@
           </code>
           <div class="tip" id="4552">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L201-201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L201-201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1557,10 +1558,10 @@
           </code>
           <div class="tip" id="4553">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L202-202" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L202-202" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1575,10 +1576,10 @@
           </code>
           <div class="tip" id="4554">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L204-204" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L204-204" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1593,10 +1594,10 @@
           </code>
           <div class="tip" id="4555">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L205-205" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L205-205" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1611,10 +1612,10 @@
           </code>
           <div class="tip" id="4556">
             <strong>Signature:</strong> unit -&gt; bool<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1632,10 +1633,10 @@
           </code>
           <div class="tip" id="4557">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1653,10 +1654,10 @@
           </code>
           <div class="tip" id="4558">
             <strong>Signature:</strong> unit -&gt; obj<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1672,10 +1673,10 @@
           </code>
           <div class="tip" id="4559">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1691,10 +1692,10 @@
           </code>
           <div class="tip" id="4560">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1712,10 +1713,10 @@
           </code>
           <div class="tip" id="4561">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1733,10 +1734,10 @@
           </code>
           <div class="tip" id="4562">
             <strong>Signature:</strong> unit -&gt; Font<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1752,10 +1753,10 @@
           </code>
           <div class="tip" id="4563">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1771,10 +1772,10 @@
           </code>
           <div class="tip" id="4564">
             <strong>Signature:</strong> unit -&gt; float<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1792,10 +1793,10 @@
           </code>
           <div class="tip" id="4565">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1813,10 +1814,10 @@
           </code>
           <div class="tip" id="4566">
             <strong>Signature:</strong> unit -&gt; Xaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1832,10 +1833,10 @@
           </code>
           <div class="tip" id="4567">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1851,10 +1852,10 @@
           </code>
           <div class="tip" id="4568">
             <strong>Signature:</strong> unit -&gt; Xaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1870,10 +1871,10 @@
           </code>
           <div class="tip" id="4569">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1889,10 +1890,10 @@
           </code>
           <div class="tip" id="4570">
             <strong>Signature:</strong> unit -&gt; Xaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1908,10 +1909,10 @@
           </code>
           <div class="tip" id="4571">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1927,10 +1928,10 @@
           </code>
           <div class="tip" id="4572">
             <strong>Signature:</strong> unit -&gt; Yaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1946,10 +1947,10 @@
           </code>
           <div class="tip" id="4573">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1965,10 +1966,10 @@
           </code>
           <div class="tip" id="4574">
             <strong>Signature:</strong> unit -&gt; Yaxis<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -1984,10 +1985,10 @@
           </code>
           <div class="tip" id="4575">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -2007,7 +2008,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -2070,6 +2071,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-layout.html
+++ b/docs/reference/xplot-plotly-layout.html
@@ -5,7 +5,7 @@
     <title>Layout - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -58,6 +58,11 @@
 <h1>Layout</h1>
 <p>
   <span>Namespace: XPlot.Plotly</span><br />
+        <span>
+          Attributes:<br />
+[&lt;AutoOpen&gt;]<br />
+          
+      </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -74,7 +79,9 @@
           <td class="type-name">
             <a href="xplot-plotly-layout-layout.html">Layout</a>
           </td>
-          <td class="xmldoc"></td>
+          <td class="xmldoc">
+          
+          </td>
         </tr>
     </tbody>
   </table>
@@ -91,7 +98,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -154,6 +161,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-options.html
+++ b/docs/reference/xplot-plotly-options.html
@@ -5,7 +5,7 @@
     <title>Options - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>Options</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Instance members</h3>
@@ -75,10 +76,10 @@
           </code>
           <div class="tip" id="4612">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L155-155" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -94,10 +95,10 @@
           </code>
           <div class="tip" id="4613">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L143-143" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -113,10 +114,10 @@
           </code>
           <div class="tip" id="4614">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L54-54" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -134,10 +135,10 @@
           </code>
           <div class="tip" id="4615">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L173-173" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -153,10 +154,10 @@
           </code>
           <div class="tip" id="4616">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L177-177" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -172,10 +173,10 @@
           </code>
           <div class="tip" id="4617">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L169-169" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -191,10 +192,10 @@
           </code>
           <div class="tip" id="4618">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L181-181" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -210,10 +211,10 @@
           </code>
           <div class="tip" id="4619">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L160-160" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -231,10 +232,10 @@
           </code>
           <div class="tip" id="4620">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L102-102" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -252,10 +253,10 @@
           </code>
           <div class="tip" id="4621">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L40-40" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -271,10 +272,10 @@
           </code>
           <div class="tip" id="4622">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L135-135" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -290,10 +291,10 @@
           </code>
           <div class="tip" id="4623">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L64-64" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -311,10 +312,10 @@
           </code>
           <div class="tip" id="4624">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L88-88" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -332,10 +333,10 @@
           </code>
           <div class="tip" id="4625">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L107-107" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -353,10 +354,10 @@
           </code>
           <div class="tip" id="4626">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L139-139" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -372,10 +373,10 @@
           </code>
           <div class="tip" id="4627">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L68-68" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -391,10 +392,10 @@
           </code>
           <div class="tip" id="4628">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L165-165" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -412,10 +413,10 @@
           </code>
           <div class="tip" id="4629">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L73-73" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -433,10 +434,10 @@
           </code>
           <div class="tip" id="4630">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L78-78" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -454,10 +455,10 @@
           </code>
           <div class="tip" id="4631">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L151-151" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -473,10 +474,10 @@
           </code>
           <div class="tip" id="4632">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L131-131" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -492,10 +493,10 @@
           </code>
           <div class="tip" id="4633">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L83-83" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -513,10 +514,10 @@
           </code>
           <div class="tip" id="4634">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -532,10 +533,10 @@
           </code>
           <div class="tip" id="4635">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L97-97" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -553,10 +554,10 @@
           </code>
           <div class="tip" id="4636">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L92-92" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -572,10 +573,10 @@
           </code>
           <div class="tip" id="4637">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L45-45" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -593,10 +594,10 @@
           </code>
           <div class="tip" id="4638">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L49-49" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -612,10 +613,10 @@
           </code>
           <div class="tip" id="4639">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L59-59" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -633,10 +634,10 @@
           </code>
           <div class="tip" id="4640">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L111-111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -652,10 +653,10 @@
           </code>
           <div class="tip" id="4641">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L115-115" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -671,10 +672,10 @@
           </code>
           <div class="tip" id="4642">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L119-119" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -690,10 +691,10 @@
           </code>
           <div class="tip" id="4643">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L123-123" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -709,10 +710,10 @@
           </code>
           <div class="tip" id="4644">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Layout.fs#L127-127" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -732,7 +733,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -795,6 +796,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-plotly.html
+++ b/docs/reference/xplot-plotly-plotly.html
@@ -5,7 +5,7 @@
     <title>Plotly - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,7 +57,17 @@
 
 <h1>Plotly</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
+
+        <div class="alert alert-warning">
+        <strong>WARNING: </strong> This API is obsolete
+        <p>Use the Chart type instead.</p>
+        </div> 
+    <span>Namespace: XPlot.Plotly</span><br />
+            <span>
+            Attributes: <br />
+[&lt;Obsolete(&quot;Use the Chart type instead.&quot;)&gt;]<br />
+            
+        </span>
 </p>
 <div class="xmldoc">
 </div>
@@ -71,7 +81,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -134,6 +144,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-plotlychart.html
+++ b/docs/reference/xplot-plotly-plotlychart.html
@@ -5,7 +5,7 @@
     <title>PlotlyChart - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>PlotlyChart</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+    </p>
 <div class="xmldoc">
 </div>
   <h3>Record Fields</h3>
@@ -76,10 +77,14 @@
           <div class="tip" id="4645">
             <strong>Signature:</strong> seq&lt;string&gt; option<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L66-66" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L66-66" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -95,10 +100,14 @@
           <div class="tip" id="4646">
             <strong>Signature:</strong> Layout option<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L63-63" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L63-63" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -114,10 +123,14 @@
           <div class="tip" id="4647">
             <strong>Signature:</strong> seq&lt;Trace&gt;<br />
               <strong>Modifiers:</strong> mutable<br />
-                      </div>
+                                    <span>
+            <strong>Attributes:</strong><br />
+[&lt;DefaultValue&gt;]<br />
+          </span>
+          </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L50-50" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L50-50" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -140,10 +153,10 @@
           </code>
           <div class="tip" id="4648">
             <strong>Signature:</strong> unit -&gt; PlotlyChart<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L47-47" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L47-47" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -167,10 +180,10 @@
           </code>
           <div class="tip" id="4649">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L69-69" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L69-69" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -187,10 +200,10 @@
           </code>
           <div class="tip" id="4650">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L85-85" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L85-85" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -207,10 +220,10 @@
           </code>
           <div class="tip" id="4651">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L99-99" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L99-99" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -227,10 +240,10 @@
           </code>
           <div class="tip" id="4652">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L111-111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L111-111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -248,10 +261,10 @@
           </code>
           <div class="tip" id="4653">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L111-111" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L111-111" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -269,10 +282,10 @@
           </code>
           <div class="tip" id="4654">
             <strong>Signature:</strong> unit -&gt; string<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L114-114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L114-114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -290,10 +303,10 @@
           </code>
           <div class="tip" id="4655">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L114-114" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L114-114" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -310,11 +323,11 @@
             Plot(data, Layout, Labels)
           </code>
           <div class="tip" id="4656">
-            <strong>Signature:</strong> (data:seq&lt;&#39;?9129&gt; * Layout:Layout option * Labels:seq&lt;string&gt; option) -&gt; unit<br />
-                          <strong>Type parameters:</strong> '?9129          </div>
+            <strong>Signature:</strong> (data:seq&lt;&#39;?9620&gt; * Layout:Layout option * Labels:seq&lt;string&gt; option) -&gt; unit<br />
+                          <strong>Type parameters:</strong> '?9620                      </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L118-118" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L118-118" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -329,10 +342,10 @@
           </code>
           <div class="tip" id="4657">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L125-125" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L125-125" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -347,10 +360,10 @@
           </code>
           <div class="tip" id="4658">
             <strong>Signature:</strong> unit -&gt; int<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L144-144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L144-144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -368,10 +381,10 @@
           </code>
           <div class="tip" id="4659">
             <strong>Signature:</strong> unit -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L144-144" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L144-144" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -389,10 +402,10 @@
           </code>
           <div class="tip" id="4660">
             <strong>Signature:</strong> height:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L147-147" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L147-147" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -409,10 +422,10 @@
           </code>
           <div class="tip" id="4661">
             <strong>Signature:</strong> newId:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L150-150" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L150-150" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -429,10 +442,10 @@
           </code>
           <div class="tip" id="4662">
             <strong>Signature:</strong> label:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L154-154" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L154-154" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -450,10 +463,10 @@ chart's data is a single series.</p>
           </code>
           <div class="tip" id="4663">
             <strong>Signature:</strong> labels:seq&lt;string&gt; -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L158-158" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L158-158" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -471,10 +484,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4664">
             <strong>Signature:</strong> layoutObj:Layout -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L161-161" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L161-161" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -491,10 +504,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4665">
             <strong>Signature:</strong> enabled:bool -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L164-164" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L164-164" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -511,10 +524,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4666">
             <strong>Signature:</strong> options:Layout -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L172-172" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L172-172" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -531,10 +544,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4667">
             <strong>Signature:</strong> (width:int * height:int) -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L175-175" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L175-175" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -551,10 +564,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4668">
             <strong>Signature:</strong> title:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L180-180" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L180-180" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -571,10 +584,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4669">
             <strong>Signature:</strong> width:int -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L188-188" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L188-188" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -591,10 +604,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4670">
             <strong>Signature:</strong> xTitle:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L191-191" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L191-191" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -611,10 +624,10 @@ chart's data is a series collection.</p>
           </code>
           <div class="tip" id="4671">
             <strong>Signature:</strong> yTitle:string -&gt; unit<br />
-                      </div>
+                                  </div>
         </td>
         <td class="xmldoc">
-            <a href="http://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L201-201" class="github-link">
+                      <a href="https://github.com/fslaborg/XPlot/tree/master/src/XPlot.Plotly/Main.fs#L201-201" class="github-link">
               <img src="../content/img/github.png" class="normal" />
               <img src="../content/img/github-blue.png" class="hover" />
             </a>
@@ -635,7 +648,7 @@ chart's data is a series collection.</p>
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -698,6 +711,6 @@ chart's data is a series collection.</p>
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/reference/xplot-plotly-value.html
+++ b/docs/reference/xplot-plotly-value.html
@@ -5,7 +5,7 @@
     <title>value - XPlot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
@@ -57,8 +57,9 @@
 
 <h1>value</h1>
 <p>
-  <span>Namespace: XPlot.Plotly</span><br />
-</p>
+
+    <span>Namespace: XPlot.Plotly</span><br />
+    </p>
 <div class="xmldoc">
 </div>
 
@@ -71,7 +72,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -134,6 +135,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -5,16 +5,18 @@
     <title>release-notes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Data visualization library for F#" />
-    <meta name="author" content="Taha Hachana; Tomas Petricek" />
+    <meta name="author" content="Taha Hachana, Tomas Petricek" />
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />
@@ -50,6 +52,12 @@
         <div class="row">
             <div class="span9" id="main">
                 
+<h3><a name="1-5-0-August-6-2018" class="anchor" href="#1-5-0-August-6-2018">1.5.0 - August 6, 2018</a></h3>
+<ul>
+<li>Update to FSHarp.Core 4.5.0.0</li>
+<li>Use proper google download links</li>
+<li>Doc updates</li>
+</ul>
 <h3><a name="1-4-5-February-16-2018" class="anchor" href="#1-4-5-February-16-2018">1.4.5 - February 16, 2018</a></h3>
 <ul>
 <li>Fixing documentation template</li>
@@ -170,7 +178,7 @@
                     <li><a href="/XPlot/quickstart.html">Getting started</a></li>
                     <li class="divider"></li>
                     <li><a href="http://www.nuget.org/packages?q=XPlot">Get Library via NuGet</a></li>
-                    <li><a href="http://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
+                    <li><a href="https://github.com/fslaborg/XPlot">Source Code on GitHub</a></li>
                     <li><a href="/XPlot/license.html">License (Apache 2.0)</a></li>
                     <li><a href="/XPlot/release-notes.html">Release Notes</a></li>
 
@@ -214,6 +222,9 @@
                     <li><a href="/XPlot/chart/plotly-3d-surface-plots.html">3D Surface Plots</a></li>
                     <li><a href="/XPlot/chart/plotly-3d-line-plots.html">3D Line Plots</a></li>
 
+                    <li class="nav-header"><a href="/XPlot/d3.html">D3 Charts</a></li>
+                    <li><a href="/XPlot/chart/d3-network.html">Network</a></li>
+
                     <li class="nav-header">Documentation</li>
                     <li><a href="/XPlot/reference/index.html">API Reference</a></li>
                     <li class="divider"></li>
@@ -230,6 +241,6 @@
             </div>
         </div>
     </div>
-    <a href="http://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/fslaborg/XPlot"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
 </body>
 </html>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -13,9 +13,11 @@
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet" />
 
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.load("visualization", "1.1", { packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"] })
+        google.charts.load('current', {
+            packages: ["corechart", "annotationchart", "calendar", "gauge", "geochart", "map", "sankey", "table", "timeline", "treemap"]
+        });
     </script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link type="text/css" rel="stylesheet" href="/XPlot/content/style.css" />

--- a/docsrc/content/release-notes.md
+++ b/docsrc/content/release-notes.md
@@ -1,3 +1,8 @@
+### 1.5.0 - August 6, 2018
+* Update to FSHarp.Core 4.5.0.0
+* Use proper google download links
+* Doc updates
+
 ### 1.4.5 - February 16, 2018
 * Fixing documentation template
 

--- a/src/XPlot.D3/AssemblyInfo.fs
+++ b/src/XPlot.D3/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.D3")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("1.4.5")>]
-[<assembly: AssemblyFileVersionAttribute("1.4.5")>]
+[<assembly: AssemblyVersionAttribute("1.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.D3"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "1.4.5"
-    let [<Literal>] AssemblyFileVersion = "1.4.5"
+    let [<Literal>] AssemblyVersion = "1.5.0"
+    let [<Literal>] AssemblyFileVersion = "1.5.0"

--- a/src/XPlot.GoogleCharts.Deedle/AssemblyInfo.fs
+++ b/src/XPlot.GoogleCharts.Deedle/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.GoogleCharts.Deedle")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("1.4.5")>]
-[<assembly: AssemblyFileVersionAttribute("1.4.5")>]
+[<assembly: AssemblyVersionAttribute("1.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.GoogleCharts.Deedle"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "1.4.5"
-    let [<Literal>] AssemblyFileVersion = "1.4.5"
+    let [<Literal>] AssemblyVersion = "1.5.0"
+    let [<Literal>] AssemblyFileVersion = "1.5.0"

--- a/src/XPlot.GoogleCharts/AssemblyInfo.fs
+++ b/src/XPlot.GoogleCharts/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.GoogleCharts")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("1.4.5")>]
-[<assembly: AssemblyFileVersionAttribute("1.4.5")>]
+[<assembly: AssemblyVersionAttribute("1.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.GoogleCharts"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "1.4.5"
-    let [<Literal>] AssemblyFileVersion = "1.4.5"
+    let [<Literal>] AssemblyVersion = "1.5.0"
+    let [<Literal>] AssemblyFileVersion = "1.5.0"

--- a/src/XPlot.Plotly/AssemblyInfo.fs
+++ b/src/XPlot.Plotly/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.Plotly")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("1.4.5")>]
-[<assembly: AssemblyFileVersionAttribute("1.4.5")>]
+[<assembly: AssemblyVersionAttribute("1.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.Plotly"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "1.4.5"
-    let [<Literal>] AssemblyFileVersion = "1.4.5"
+    let [<Literal>] AssemblyVersion = "1.5.0"
+    let [<Literal>] AssemblyFileVersion = "1.5.0"


### PR DESCRIPTION

@jackfoxy I've had trouble running 

    .\build Release

I had to change this to 

    .\build target Release

Also I couldn't update the docs using that or this:

    .\build target GenerateDocs

There is a failure.  I think it may be to do with the `dotnet fake` update.  Could you take a look?

Anyway, I pushed 1.5.0 which uses correct links for google assets