### PR TITLE
Use 'build' in unix build so build.sh just works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ matrix:
       sudo: required
 
 script: 
-  - ./build.sh build target all
+  - ./build.sh target all
 

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 dotnet restore build.proj
-dotnet fake "$@"
+dotnet fake build "$@"


### PR DESCRIPTION
Fixes #92

`./build.sh` will just work on unix now.