### PR TITLE
Reference netstandard .dlls in scripts

### DIFF
--- a/docsrc/content/chart/d3-network.fsx
+++ b/docsrc/content/chart/d3-network.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-#I "../../../bin/XPlot.D3/net45"
+#I "../../../bin/XPlot.D3/netstandard2.0"
 #r "XPlot.D3.dll"
 open XPlot.D3
 

--- a/docsrc/content/chart/google-annotation-chart.fsx
+++ b/docsrc/content/chart/google-annotation-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 open System

--- a/docsrc/content/chart/google-area-chart.fsx
+++ b/docsrc/content/chart/google-area-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-bar-chart.fsx
+++ b/docsrc/content/chart/google-bar-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-bubble-chart.fsx
+++ b/docsrc/content/chart/google-bubble-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-calendar-chart.fsx
+++ b/docsrc/content/chart/google-calendar-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 open System

--- a/docsrc/content/chart/google-candlestick-chart.fsx
+++ b/docsrc/content/chart/google-candlestick-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-column-chart.fsx
+++ b/docsrc/content/chart/google-column-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-combo-chart.fsx
+++ b/docsrc/content/chart/google-combo-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-gauge-chart.fsx
+++ b/docsrc/content/chart/google-gauge-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-geo-chart.fsx
+++ b/docsrc/content/chart/google-geo-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 (**

--- a/docsrc/content/chart/google-histogram-chart.fsx
+++ b/docsrc/content/chart/google-histogram-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-line-chart.fsx
+++ b/docsrc/content/chart/google-line-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 (**

--- a/docsrc/content/chart/google-map-chart.fsx
+++ b/docsrc/content/chart/google-map-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-pie-chart.fsx
+++ b/docsrc/content/chart/google-pie-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-sankey-diagram.fsx
+++ b/docsrc/content/chart/google-sankey-diagram.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-scatter-chart.fsx
+++ b/docsrc/content/chart/google-scatter-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 (**

--- a/docsrc/content/chart/google-stepped-area-chart.fsx
+++ b/docsrc/content/chart/google-stepped-area-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-table-chart.fsx
+++ b/docsrc/content/chart/google-table-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/google-timeline-chart.fsx
+++ b/docsrc/content/chart/google-timeline-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 open System

--- a/docsrc/content/chart/google-treemap-chart.fsx
+++ b/docsrc/content/chart/google-treemap-chart.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.GoogleCharts/net472"
+#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts
 

--- a/docsrc/content/chart/plotly-2d-histograms.fsx
+++ b/docsrc/content/chart/plotly-2d-histograms.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #I "../../../packages/MathNet.Numerics/lib/net40"
 #r "XPlot.Plotly.dll"
 #r "MathNet.Numerics.dll"

--- a/docsrc/content/chart/plotly-3d-line-plots.fsx
+++ b/docsrc/content/chart/plotly-3d-line-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open System.IO

--- a/docsrc/content/chart/plotly-3d-scatter-plots.fsx
+++ b/docsrc/content/chart/plotly-3d-scatter-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-3d-surface-plots.fsx
+++ b/docsrc/content/chart/plotly-3d-surface-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-area-plots.fsx
+++ b/docsrc/content/chart/plotly-area-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-bar-charts.fsx
+++ b/docsrc/content/chart/plotly-bar-charts.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-box-plots.fsx
+++ b/docsrc/content/chart/plotly-box-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open System

--- a/docsrc/content/chart/plotly-bubble-charts.fsx
+++ b/docsrc/content/chart/plotly-bubble-charts.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-candlestick-plots.fsx
+++ b/docsrc/content/chart/plotly-candlestick-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 open XPlot.Plotly
 open System

--- a/docsrc/content/chart/plotly-contour-plots.fsx
+++ b/docsrc/content/chart/plotly-contour-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #I "../../../packages/MathNet.Numerics/lib/net40"
 #r "XPlot.Plotly.dll"
 #r "MathNet.Numerics.dll"

--- a/docsrc/content/chart/plotly-heatmaps.fsx
+++ b/docsrc/content/chart/plotly-heatmaps.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-histograms.fsx
+++ b/docsrc/content/chart/plotly-histograms.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #I "../../../packages/MathNet.Numerics/lib/net40"
 #r "XPlot.Plotly.dll"
 #r "MathNet.Numerics.dll"

--- a/docsrc/content/chart/plotly-line-scatter-plots.fsx
+++ b/docsrc/content/chart/plotly-line-scatter-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-log-plots.fsx
+++ b/docsrc/content/chart/plotly-log-plots.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-multiple-chart-types.fsx
+++ b/docsrc/content/chart/plotly-multiple-chart-types.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-polar-charts.fsx
+++ b/docsrc/content/chart/plotly-polar-charts.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly

--- a/docsrc/content/chart/plotly-time-series.fsx
+++ b/docsrc/content/chart/plotly-time-series.fsx
@@ -1,5 +1,5 @@
 ﻿(*** hide ***)
-#I "../../../bin/XPlot.Plotly/net472"
+#I "../../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 
 open System

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -1,6 +1,6 @@
 (*** hide ***)
-#I "../../bin/XPlot.GoogleCharts/net472"
-#I "../../bin/XPlot.Plotly/net472"
+#I "../../bin/XPlot.GoogleCharts/netstandard2.0"
+#I "../../bin/XPlot.Plotly/netstandard2.0"
 #r "XPlot.Plotly.dll"
 #r "XPlot.GoogleCharts.dll"
 open XPlot.GoogleCharts

--- a/docsrc/content/quickstart.fsx
+++ b/docsrc/content/quickstart.fsx
@@ -71,7 +71,7 @@ That's it! You should see a chart popping up in your browser.
 
 Notes
 
-- in the path `#r "XPlot.GoogleCharts/lib/net45/`, make sure "net45" is right, 
+- in the path `#r "XPlot.GoogleCharts/lib/netstandard2.0/`, make sure "net45" is right, 
 this is based on `paket.dependencies`, specifically the .NET 4.5 framework part (`framework:net45`).
 - you will need an internet connection for the chart to render, as the code relies on Google-hosted services.
 

--- a/docsrc/tools/formatters.fsx
+++ b/docsrc/tools/formatters.fsx
@@ -1,11 +1,11 @@
 module Formatters
 #I "../../packages/formatting/FSharp.Formatting"
 #load "FSharp.Formatting.fsx"
-#r "../../packages/Deedle/lib/net45/Deedle.dll"
-#r "../../bin/XPlot.GoogleCharts/net472/XPlot.GoogleCharts.dll"
-#r "../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
-#r "../../bin/XPlot.D3/net45/XPlot.D3.dll"
-#r "../../packages/formatting/FSharp.Compiler.Service/lib/net45/FSharp.Compiler.Service.dll"
+#r "../../packages/Deedle/lib/netstandard2.0/Deedle.dll"
+#r "../../bin/XPlot.GoogleCharts/netstandard2.0/XPlot.GoogleCharts.dll"
+#r "../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
+#r "../../bin/XPlot.D3/netstandard2.0/XPlot.D3.dll"
+#r "../../packages/formatting/FSharp.Compiler.Service/lib/netstandard2.0/FSharp.Compiler.Service.dll"
 #r "netstandard"
 // --------------------------------------------------------------------------------------
 // NOTE: Most of this file is the same as in FsLab (https://github.com/fslaborg/FsLab)

--- a/docsrc/tools/generate.fsx
+++ b/docsrc/tools/generate.fsx
@@ -34,10 +34,10 @@ open FSharp.Formatting.Razor
 // Binaries for which to generate XML documentation
 let referenceBinaries = 
   [ 
-    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.D3/net45/XPlot.D3.dll"
-    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.GoogleCharts/net472/XPlot.GoogleCharts.dll"
-    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.GoogleCharts.Deedle/net45/XPlot.GoogleCharts.Deedle.dll"
-    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.D3/netstandard2.0/XPlot.D3.dll"
+    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.GoogleCharts/netstandard2.0/XPlot.GoogleCharts.dll"
+    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0/XPlot.GoogleCharts.Deedle.dll"
+    __SOURCE_DIRECTORY__ + "/../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
   ]
 
 // When called from 'build.fsx', use the public project URL as <root>

--- a/src/XPlot.GoogleCharts.Deedle/tests/Annotation.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Annotation.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Area.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Area.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Bar.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Bar.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Bubble.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Bubble.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Calendar.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Calendar.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Candlestick.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Candlestick.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts.Deedle/tests/Column.fsx
+++ b/src/XPlot.GoogleCharts.Deedle/tests/Column.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts.Deedle/netstandard2.0"
 #r "Deedle.dll"
 #r "XPlot.GoogleCharts.dll"
 #r "XPlot.GoogleCharts.Deedle.dll"

--- a/src/XPlot.GoogleCharts/tests/Annotation.fsx
+++ b/src/XPlot.GoogleCharts/tests/Annotation.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open System

--- a/src/XPlot.GoogleCharts/tests/Area.fsx
+++ b/src/XPlot.GoogleCharts/tests/Area.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Bar.fsx
+++ b/src/XPlot.GoogleCharts/tests/Bar.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Bubble.fsx
+++ b/src/XPlot.GoogleCharts/tests/Bubble.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Calendar.fsx
+++ b/src/XPlot.GoogleCharts/tests/Calendar.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open System

--- a/src/XPlot.GoogleCharts/tests/Candlestick.fsx
+++ b/src/XPlot.GoogleCharts/tests/Candlestick.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/ChartType.fsx
+++ b/src/XPlot.GoogleCharts/tests/ChartType.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Column.fsx
+++ b/src/XPlot.GoogleCharts/tests/Column.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Combo.fsx
+++ b/src/XPlot.GoogleCharts/tests/Combo.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Gauge.fsx
+++ b/src/XPlot.GoogleCharts/tests/Gauge.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Geo.fsx
+++ b/src/XPlot.GoogleCharts/tests/Geo.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Histogram.fsx
+++ b/src/XPlot.GoogleCharts/tests/Histogram.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Line.fsx
+++ b/src/XPlot.GoogleCharts/tests/Line.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Map.fsx
+++ b/src/XPlot.GoogleCharts/tests/Map.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Pie.fsx
+++ b/src/XPlot.GoogleCharts/tests/Pie.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Sankey.fsx
+++ b/src/XPlot.GoogleCharts/tests/Sankey.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Scatter.fsx
+++ b/src/XPlot.GoogleCharts/tests/Scatter.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/SteppedArea.fsx
+++ b/src/XPlot.GoogleCharts/tests/SteppedArea.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Table.fsx
+++ b/src/XPlot.GoogleCharts/tests/Table.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.GoogleCharts/tests/Timeline.fsx
+++ b/src/XPlot.GoogleCharts/tests/Timeline.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open System

--- a/src/XPlot.GoogleCharts/tests/Treemap.fsx
+++ b/src/XPlot.GoogleCharts/tests/Treemap.fsx
@@ -1,4 +1,4 @@
-﻿#I "../../../bin/XPlot.GoogleCharts/net472"
+﻿#I "../../../bin/XPlot.GoogleCharts/netstandard2.0"
 #r "XPlot.GoogleCharts.dll"
 
 open XPlot.GoogleCharts

--- a/src/XPlot.Plotly/Graph.fsx
+++ b/src/XPlot.Plotly/Graph.fsx
@@ -1,5 +1,5 @@
 ﻿
-#r @"../../packages/Newtonsoft.Json/lib/net45/Newtonsoft.Json.dll"
+#r @"../../packages/Newtonsoft.Json/lib/netstandard2.0/Newtonsoft.Json.dll"
 
 open Newtonsoft.Json
 open System

--- a/src/XPlot.Plotly/Tests/Area.fsx
+++ b/src/XPlot.Plotly/Tests/Area.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Bar.fsx
+++ b/src/XPlot.Plotly/Tests/Bar.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Bubble.fsx
+++ b/src/XPlot.Plotly/Tests/Bubble.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Column.fsx
+++ b/src/XPlot.Plotly/Tests/Column.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Gauge.fsx
+++ b/src/XPlot.Plotly/Tests/Gauge.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 open System

--- a/src/XPlot.Plotly/Tests/Line.fsx
+++ b/src/XPlot.Plotly/Tests/Line.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/MultipleChartTypes.fsx
+++ b/src/XPlot.Plotly/Tests/MultipleChartTypes.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 open System

--- a/src/XPlot.Plotly/Tests/Pie.fsx
+++ b/src/XPlot.Plotly/Tests/Pie.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Scatter.fsx
+++ b/src/XPlot.Plotly/Tests/Scatter.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 

--- a/src/XPlot.Plotly/Tests/Shapes.fsx
+++ b/src/XPlot.Plotly/Tests/Shapes.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 #r "../../../packages/MathNet.Numerics/lib/net40/MathNet.Numerics.dll"
 
 open System

--- a/src/XPlot.Plotly/Tests/Subplots.fsx
+++ b/src/XPlot.Plotly/Tests/Subplots.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 #r "../../../packages/MathNet.Numerics/lib/net40/MathNet.Numerics.dll"
 
 open System

--- a/src/XPlot.Plotly/Tests/TimeSeries.fsx
+++ b/src/XPlot.Plotly/Tests/TimeSeries.fsx
@@ -1,4 +1,4 @@
-﻿#r @"../../../bin/XPlot.Plotly/net472/XPlot.Plotly.dll"
+﻿#r @"../../../bin/XPlot.Plotly/netstandard2.0/XPlot.Plotly.dll"
 
 open XPlot.Plotly
 


### PR DESCRIPTION
Note: with `dotnet fsi` on the mac (released `dotnet fsi`) these fail to load the transitive references to Newtonsoft.Json et. al. However, the stack trace clearly indicates that these scripts were executed and failed in the XPlot.Plotly `.dll` itself where it loads and uses JSON.NET  in `XPlot.Plotly.PlotlyChart.GetInlineHtml()`.