### PR TITLE
Improve html generation api

### DIFF
--- a/src/XPlot.GoogleCharts/Main.fs
+++ b/src/XPlot.GoogleCharts/Main.fs
@@ -168,8 +168,8 @@ module Html =
         """
 
     let jsTemplate =
-        """google.charts.setOnLoadCallback(drawChart);
-            function drawChart() {
+        """google.charts.setOnLoadCallback(drawChart_{GUID});
+            function drawChart_{GUID}() {
                 if ("{KEY}")
                     google.visualization.mapsApiKey = "{KEY}"
 

--- a/src/XPlot.GoogleCharts/XPlot.GoogleCharts.fsproj
+++ b/src/XPlot.GoogleCharts/XPlot.GoogleCharts.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/XPlot.Plotly/Main.fs
+++ b/src/XPlot.Plotly/Main.fs
@@ -23,17 +23,18 @@ module Html =
     let inlineTemplate =
         """<div id="[ID]" style="width: [WIDTH]px; height: [HEIGHT]px;"></div>
         <script>
-            var data = [DATA];
-            var layout = [LAYOUT];
-            Plotly.newPlot('[ID]', data, layout);
+            [PLOTTING]
         </script>"""
 
     let jsTemplate =
         """<script>
-            var data = [DATA];
-            var layout = [LAYOUT];
-            Plotly.newPlot('[ID]', data, layout);
-        </script>"""
+            [PLOTTING]
+        </script>"""   
+
+    let jsFunctionTemplate =
+        """var data = [DATA];
+           var layout = [LAYOUT];
+           Plotly.newPlot('[ID]', data, layout);"""  
     
     /// Display given html markup in default browser
     let showInBrowser html pageId=
@@ -76,42 +77,33 @@ type PlotlyChart() =
 
     /// Returns the chart's full HTML source.
     member __.GetHtml() =
-//        let tracesJson = serializeTraces __.labels __.traces
-//        let layoutJson =
-//            match __.layout with
-//            | None -> "\"\""
-//            | Some x -> JsonConvert.SerializeObject x
         let chartMarkup = __.GetInlineHtml()
-//            Html.inlineTemplate
-//                .Replace("[ID]", __.Id)
-//                .Replace("[WIDTH]", string __.Width)
-//                .Replace("[HEIGHT]", string __.Height)
-//                .Replace("[DATA]", tracesJson)
-//                .Replace("[LAYOUT]", layoutJson)
         Html.pageTemplate.Replace("[CHART]", chartMarkup)
 
     /// Inline markup that can be embedded in a HTML document.
     member __.GetInlineHtml() =
-        let tracesJson = serializeTraces __.labels __.traces
-        let layoutJson =
-            match __.layout with
-            | None -> "\"\""
-            | Some x -> JsonConvert.SerializeObject x
+        let plotting = __.GetPlottingJS()
         Html.inlineTemplate
             .Replace("[ID]", __.Id)
             .Replace("[WIDTH]", string __.Width)
             .Replace("[HEIGHT]", string __.Height)
-            .Replace("[DATA]", tracesJson)
-            .Replace("[LAYOUT]", layoutJson)
+            .Replace("[PLOTTING]", plotting)
 
     /// The chart's inline JavaScript code.
     member __.GetInlineJS() =
+        let plotting = __.GetPlottingJS()
+        Html.jsTemplate
+            .Replace("[ID]", __.Id)
+            .Replace("[PLOTTING]", plotting)
+    
+    /// The chart's plotting JavaScript code.
+    member __.GetPlottingJS() =
         let tracesJson = serializeTraces __.labels __.traces
         let layoutJson =
             match __.layout with
             | None -> "\"\""
             | Some x -> JsonConvert.SerializeObject x
-        Html.jsTemplate
+        Html.jsFunctionTemplate
             .Replace("[ID]", __.Id)
             .Replace("[DATA]", tracesJson)
             .Replace("[LAYOUT]", layoutJson)
@@ -132,20 +124,6 @@ type PlotlyChart() =
         __.labels <- Labels
 
     member __.Show() =
-//        let tracesJson = serializeTraces __.labels __.traces
-//        let layoutJson =
-//            match __.layout with
-//            | None -> "\"\""
-//            | Some x -> JsonConvert.SerializeObject x
-//        let html =
-//            let chartMarkup =
-//                Html.inlineTemplate
-//                    .Replace("[ID]", __.Id)
-//                    .Replace("[WIDTH]", string __.Width)
-//                    .Replace("[HEIGHT]", string __.Height)
-//                    .Replace("[DATA]", tracesJson)
-//                    .Replace("[LAYOUT]", layoutJson)
-//            Html.pageTemplate.Replace("[CHART]", chartMarkup)
         let html = __.GetHtml()
         Html.showInBrowser html __.Id        
 


### PR DESCRIPTION
in Google Chart use id to isolate rendering callbacks
in Plotly refactor code to generate plain js plotting code