### PR TITLE
Don't use TargetFrameworks

### DIFF
--- a/src/XPlot.D3/XPlot.D3.fsproj
+++ b/src/XPlot.D3/XPlot.D3.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/XPlot.GoogleCharts.Deedle/XPlot.GoogleCharts.Deedle.fsproj
+++ b/src/XPlot.GoogleCharts.Deedle/XPlot.GoogleCharts.Deedle.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/XPlot.GoogleCharts/XPlot.GoogleCharts.fsproj
+++ b/src/XPlot.GoogleCharts/XPlot.GoogleCharts.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/XPlot.Plotly/XPlot.Plotly.fsproj
+++ b/src/XPlot.Plotly/XPlot.Plotly.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This shaves off some time from the build since the mere presence of TargetFrameworks adds some overhead