### PR TITLE
add axref and ayref

### DIFF
--- a/src/XPlot.Plotly/PlotBase/Annotation.fs
+++ b/src/XPlot.Plotly/PlotBase/Annotation.fs
@@ -16,7 +16,9 @@ type Annotation() =
     let mutable _arrowhead: int option = None
     let mutable _arrowsize: float option = None
     let mutable _arrowwidth: float option = None
+    let mutable _axref: _ option = None
     let mutable _ax: float option = None
+    let mutable _ayref: _ option = None
     let mutable _ay: float option = None
     let mutable _xref: _ option = None
     let mutable _x: _ option = None
@@ -94,10 +96,20 @@ type Annotation() =
         with get () = Option.get _arrowwidth
         and set value = _arrowwidth <- Some value
 
+    /// Sets the annotation's ax coordinate axis. If set to an x axis id (e.g. *x* or *x2*), the `ax` position refers to an x coordinate If set to *paper*, the `ax` position refers to the distance from the left side of the plotting area in normalized coordinates where 0 (1) corresponds to the left (right) side.
+    member __.axref
+        with get () = Option.get _axref
+        and set value = _axref <- Some value
+
     /// Sets the x component of the arrow tail about the arrow head. A positive (negative) component corresponds to an arrow pointing from right to left (left to right)
     member __.ax
         with get () = Option.get _ax
         and set value = _ax <- Some value
+
+    /// Sets the annotation's ay coordinate axis. If set to an y axis id (e.g. *y* or *y2*), the `ay` position refers to an y coordinate If set to *paper*, the `ay` position refers to the distance from the bottom of the plotting area in normalized coordinates where 0 (1) corresponds to the bottom (top).
+    member __.ayref
+        with get () = Option.get _ayref
+        and set value = _ayref <- Some value
 
     /// Sets the y component of the arrow tail about the arrow head. A positive (negative) component corresponds to an arrow pointing from bottom to top (top to bottom)
     member __.ay
@@ -148,7 +160,9 @@ type Annotation() =
     member __.ShouldSerializearrowhead() = not _arrowhead.IsNone
     member __.ShouldSerializearrowsize() = not _arrowsize.IsNone
     member __.ShouldSerializearrowwidth() = not _arrowwidth.IsNone
+    member __.ShouldSerializeaxref() = not _axref.IsNone
     member __.ShouldSerializeax() = not _ax.IsNone
+    member __.ShouldSerializeayref() = not _ayref.IsNone
     member __.ShouldSerializeay() = not _ay.IsNone
     member __.ShouldSerializexref() = not _xref.IsNone
     member __.ShouldSerializex() = not _x.IsNone


### PR DESCRIPTION
Hello!

summary: 
I added the `axref` and `ayref` fields for the Plotly `Annotation`s. I'm sorry if this wasn't the right way to address an issue for this repo. If it isn't, please let me know what I should do and I will be happy to go through the proper channels!

long:
I was using the new and amazing .NET Interactive Notebooks extension in VSCode and was attempting to use annotations as a pseudo "vector". I was struggling with `ax` and `ay` being tied to pixel values. I noticed the JS version has an `ayref` and `axref` but XPlot doesn't. Looking through the code it seemed like all of the hard stuff would be handled for me if I just added `axref` and `ayref` to the Annotation.fs file.

It looks like it works. A quick modification to one of the tests/scripts/XPlot.Plotly/ fsx scripts generated a nice "vector" for me:
```fsharp
module Chart1Point5 =

    let from = (0, 0)
    let to' = (6, 4)
    let (arrowx, arrowy) = to'

    let options = Options(annotations = seq { 
        Annotation(showarrow = true, x = arrowx, y = arrowy, axref = "x", ayref = "y", ax = 0.0, ay = 0.0, arrowcolor = "red") 
    })

    [from; to'] 
    |> Chart.Line 
    |> Chart.WithOptions options
    |> Chart.Show
```

generates:
![newplot (1)](https://user-images.githubusercontent.com/18746421/99323773-8172dc00-2838-11eb-9dc3-68cfb17af5de.png)

For the comments, I copied the `xref` and `yref` comments and modified them to say `ax` and `ay` since they should be operating the same (I hope). Hopefully that is ok, but if I need to do more research on how it works and provide a better comment I'm happy to do so. Let me know what is required.

I wasn't sure what kinds of tests, if any, might be required. If tests are required for new code. Let me know what I need to do. I wasn't sure.

Thanks!