### PR TITLE
Bump to 4.0.1 to unblock .NET Interactive with unsaved ipynbs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 4.0.1
+
+* Bump dependencies on .NET Interactive to fix issue where plots wouldn't render in unsaved documents.
+
 ### 4.0.0
 
 * Breaking change: C# consumers now have all chart types in scope. No need to prefix charts with `Chart` anymore.

--- a/src/XPlot.D3/AssemblyInfo.fs
+++ b/src/XPlot.D3/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.D3")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("4.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.0")>]
+[<assembly: AssemblyVersionAttribute("4.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.D3"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "4.0.0"
-    let [<Literal>] AssemblyFileVersion = "4.0.0"
+    let [<Literal>] AssemblyVersion = "4.0.1"
+    let [<Literal>] AssemblyFileVersion = "4.0.1"

--- a/src/XPlot.GoogleCharts.Deedle/AssemblyInfo.fs
+++ b/src/XPlot.GoogleCharts.Deedle/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.GoogleCharts.Deedle")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("4.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.0")>]
+[<assembly: AssemblyVersionAttribute("4.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.GoogleCharts.Deedle"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "4.0.0"
-    let [<Literal>] AssemblyFileVersion = "4.0.0"
+    let [<Literal>] AssemblyVersion = "4.0.1"
+    let [<Literal>] AssemblyFileVersion = "4.0.1"

--- a/src/XPlot.GoogleCharts/AssemblyInfo.fs
+++ b/src/XPlot.GoogleCharts/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.GoogleCharts")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("4.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.0")>]
+[<assembly: AssemblyVersionAttribute("4.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.GoogleCharts"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "4.0.0"
-    let [<Literal>] AssemblyFileVersion = "4.0.0"
+    let [<Literal>] AssemblyVersion = "4.0.1"
+    let [<Literal>] AssemblyFileVersion = "4.0.1"

--- a/src/XPlot.Plotly.Interactive/AssemblyInfo.fs
+++ b/src/XPlot.Plotly.Interactive/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.Plotly.Interactive")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("4.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.0")>]
+[<assembly: AssemblyVersionAttribute("4.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.Plotly.Interactive"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "4.0.0"
-    let [<Literal>] AssemblyFileVersion = "4.0.0"
+    let [<Literal>] AssemblyVersion = "4.0.1"
+    let [<Literal>] AssemblyFileVersion = "4.0.1"

--- a/src/XPlot.Plotly.Interactive/XPlot.Plotly.Interactive.fsproj
+++ b/src/XPlot.Plotly.Interactive/XPlot.Plotly.Interactive.fsproj
@@ -23,9 +23,9 @@
 
   <ItemGroup>
     <PackageReference Include="Giraffe.ViewEngine" Version="1.2.0" />
-    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.21103.1" />
-    <PackageReference Include="Microsoft.DotNet.Interactive.PowerShell" Version="1.0.0-beta.21103.1" />
-    <PackageReference Include="Microsoft.Dotnet.Interactive.http" Version="1.0.0-beta.21103.1" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.21176.4" />
+    <PackageReference Include="Microsoft.DotNet.Interactive.PowerShell" Version="1.0.0-beta.21176.4" />
+    <PackageReference Include="Microsoft.Dotnet.Interactive.http" Version="1.0.0-beta.21176.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XPlot.Plotly/AssemblyInfo.fs
+++ b/src/XPlot.Plotly/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("XPlot.Plotly")>]
 [<assembly: AssemblyProductAttribute("XPlot")>]
 [<assembly: AssemblyDescriptionAttribute("Data visualization library for F#")>]
-[<assembly: AssemblyVersionAttribute("4.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.0")>]
+[<assembly: AssemblyVersionAttribute("4.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "XPlot.Plotly"
     let [<Literal>] AssemblyProduct = "XPlot"
     let [<Literal>] AssemblyDescription = "Data visualization library for F#"
-    let [<Literal>] AssemblyVersion = "4.0.0"
-    let [<Literal>] AssemblyFileVersion = "4.0.0"
+    let [<Literal>] AssemblyVersion = "4.0.1"
+    let [<Literal>] AssemblyFileVersion = "4.0.1"


### PR DESCRIPTION
Should resolve https://github.com/dotnet/interactive/issues/1197