### PR TITLE
Remove deleted argument to VisitSubkernelsAndSelf

### DIFF
--- a/src/XPlot.Plotly.Interactive/KernelExtension.fs
+++ b/src/XPlot.Plotly.Interactive/KernelExtension.fs
@@ -86,7 +86,7 @@ var renderPlotly = function() {{
                 | :? PowerShellKernel -> configurePowerShellKernel()
                 | _ -> ()
 
-            kernel.VisitSubkernelsAndSelf(Action<Kernel>(visitKernels),true)
+            kernel.VisitSubkernelsAndSelf(Action<Kernel>(visitKernels))
             KernelInvocationContext.Current.DisplayAs("Installed support for XPlot.Plotly.","text/markdown") |> ignore
             Task.CompletedTask
 


### PR DESCRIPTION
In https://github.com/dotnet/interactive/pull/3563, the `VisitSubkernelsAndSelf` method (in `src/Microsoft.DotNet.Interactive/KernelExtensions.cs`) was updated to remove the `recursive` argument, which breaks XPlot:

``` diff
     public static void VisitSubkernelsAndSelf(
         this Kernel kernel,
-        Action<Kernel> onVisit,
-        bool recursive = false)
+        Action<Kernel> onVisit)
     {
         if (kernel is null)
```

This should fix the binding, though I haven't built or tested anything yet.

Two possible issues:
- This should still be able to build against older versions of `Microsoft.DotNet.Interactive` because they had a default value for the deleted argument, but binaries will need to run against compatible versions because the signature of the call is explicit in the IL.  Specifically, new XPlot won't work with old Interactive.
- New `VisitSubkernelsAndSelf` is only non-recursive, so this is a behavior change from before (which passed `true`).